### PR TITLE
Fix computation of response length in the general case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Bug Fixes
 
+* PPO: fix response length calculation when using a custom end string in `sampling_params.end_strings` that is different from `<extra_id_1>`.
+
 ## [1.0.0] - 2023-11-06
 ### Added
 - First open source release


### PR DESCRIPTION
# What does this PR do ?

Get rid of the <extra_id_1>-specific code for response length calculation, that does not work for other end strings.

# Changelog 

* PPO: fix response length calculation when using a custom end string in `sampling_params.end_strings` that is different from `<extra_id_1>`.


# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? Make sure to also update the [NeMo Framework User Guide](https://docs.nvidia.com/nemo-framework/user-guide/latest/index.html) which contains the tutorials


# Remark

This PR has not yet been tested with the github version.