### PR TITLE
Change default data format from mmap to jsonl in RM / PPO

### DIFF
--- a/examples/nlp/gpt/conf/gpt_ppo_actor.yaml
+++ b/examples/nlp/gpt/conf/gpt_ppo_actor.yaml
@@ -166,7 +166,7 @@ model:
   precision: ${trainer.precision}
 
   data:
-    data_impl: mmap
+    data_impl: jsonl
     splits_string: null
     seq_length: ${model.encoder_seq_length}
     skip_warmup: True

--- a/examples/nlp/gpt/conf/training_rm.yaml
+++ b/examples/nlp/gpt/conf/training_rm.yaml
@@ -93,7 +93,7 @@ model:
       min_lr: 9e-7
 
   data:
-    data_impl: mmap
+    data_impl: jsonl
     splits_string: null
     seq_length: ${model.encoder_seq_length}
     skip_warmup: True


### PR DESCRIPTION
# What does this PR do ?

Change default data format from mmap to jsonl in RM / PPO.

I think it'd be best to change it for the release as changing default settings is always tricky.

Hopefully CI doesn't break...

# Changelog 
- N/A