### PR TITLE
Fix issue with data.data_prefix hyper-param overriden as a dictionary from command line

### DIFF
--- a/nemo_aligner/utils/utils.py
+++ b/nemo_aligner/utils/utils.py
@@ -122,6 +122,7 @@ def load_and_override_model_config(restore_path, model_cfg_to_overwrite, remove_
     if remove_meta_info:
         checkpoint_cfg.pop("target", None)
         checkpoint_cfg.pop("nemo_version", None)
+        checkpoint_cfg.data.pop("data_prefix", None)
 
     return OmegaConf.merge(checkpoint_cfg, model_cfg_to_overwrite)
 


### PR DESCRIPTION
# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.
 Fix issue with data.data_prefix hyper-param type ListConfig overriden with DictConfig from the model config. 

# Changelog 
- Please update the [CHANGELOG.md](/CHANGELOG.md) under next version with high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? Make sure to also update the [NeMo Framework User Guide](https://docs.nvidia.com/nemo-framework/user-guide/latest/index.html) which contains the tutorials

# Checklist when contributing a new algorithm
- [ ] Does the trainer resume and restore model state all states?
- [ ] Does the trainer support all parallelism techniques(PP, TP, DP)?
- [ ] Does the trainer support `max_steps=-1` and `validation`?
- [ ] Does the trainer only call APIs defined in [alignable_interface.py](/nemo_aligner/models/alignable_interface.py)?
- [ ] Does the trainer have proper logging?

# Additional Information
When attempting to run RM training, there’s an issue with loading the dataset with the `data.data_prefix` hyper-param. 
The issue is with overriding the ListConfig with a DictConfig leading to an error. 