### PR TITLE
Fix instructions to sign commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thanks for the interest in contributing to NeMo-Aligner. We do all of NeMo-Align
 
 1) Make sure your PR does one thing. Have a clear answer to "What does this PR do?".
 2) Read General Principles and style guide below
-3) Make sure you sign your commits. E.g. use ``git commit -s`` when before your commit
+3) Make sure you sign your commits. E.g. use ``git commit -sS`` when committing.
 4) Make sure all unittests finish successfully before sending PR ``pytest`` or (if your dev box does not have GPU) ``pytest --cpu`` from the root folder
 5) Send your PR and request a review
 


### PR DESCRIPTION
This is so that both the "Signed-off-by" message *and* the proper GPG signature are used.

cc @gleibovich-nvidia 