### PR TITLE
Add Conservative DPO, IPO, and KTO

### DIFF
--- a/.github/workflows/sync_branch.yaml
+++ b/.github/workflows/sync_branch.yaml
@@ -1,0 +1,24 @@
+name: sync main with dev
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync-branches:
+    runs-on: ubuntu-latest
+    name: syncing main with dev
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Opening pull request
+        id: pull
+        uses: tretuna/sync-branches@1.4.0
+        with:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          FROM_BRANCH: "main"
+          TO_BRANCH: "dev"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,17 @@ Thanks for the interest in contributing to NeMo-Aligner. We do all of NeMo-Align
 
 # Pull Requests (PR) Guidelines
 
-**Send your PRs to the `main` branch**
+**Send your PRs to the `main` or `dev` branch**
 
 1) Make sure your PR does one thing. Have a clear answer to "What does this PR do?".
 2) Read General Principles and style guide below
 3) Make sure you sign your commits. E.g. use ``git commit -sS`` when committing.
 4) Make sure all unittests finish successfully before sending PR ``pytest`` or (if your dev box does not have GPU) ``pytest --cpu`` from the root folder
 5) Send your PR and request a review
+
+**NOTE**: The `main` branch uses a fixed NeMo version which we will update on every release. The `dev` branch is the branch that has all commits from `main` but uses NeMo's main branch: this branch is less stable but we run nightly tests on it to make sure everything works. We only provide the dockerfile that works with `main`, which is the branch most PRs should target unless they require the latest NeMo main (in which case they should target `dev`).
+
+Every release `dev` and `main` will sync to be the same.
 
 ## Unit tests
 Quick unit tests (locally, while developing)

--- a/examples/nlp/gpt/conf/gpt_dpo.yaml
+++ b/examples/nlp/gpt/conf/gpt_dpo.yaml
@@ -62,6 +62,7 @@ model:
     ref_policy_kl_penalty: 0.2
     average_log_probs: False
     label_smoothing: 0.0
+    preference_loss: 'dpo' # dpo | ipo
   
   #encoder_seq_length: 4096
   #max_position_embeddings: ${model.encoder_seq_length}

--- a/examples/nlp/gpt/conf/gpt_dpo.yaml
+++ b/examples/nlp/gpt/conf/gpt_dpo.yaml
@@ -61,6 +61,7 @@ model:
     log_prob_forward_micro_batch_size: 1
     ref_policy_kl_penalty: 0.2
     average_log_probs: False
+    label_smoothing: 0.0
   
   #encoder_seq_length: 4096
   #max_position_embeddings: ${model.encoder_seq_length}

--- a/examples/nlp/gpt/conf/gpt_dpo.yaml
+++ b/examples/nlp/gpt/conf/gpt_dpo.yaml
@@ -62,7 +62,7 @@ model:
     ref_policy_kl_penalty: 0.2
     average_log_probs: False
     label_smoothing: 0.0
-    preference_loss: 'dpo' # dpo | ipo
+    preference_loss: 'dpo' # dpo | ipo | kto
   
   #encoder_seq_length: 4096
   #max_position_embeddings: ${model.encoder_seq_length}


### PR DESCRIPTION
# What does this PR do ?

Adds Conservative DPO (CDPO), IPO, and KTO methods

# Changelog 
- Please update the [CHANGELOG.md](/CHANGELOG.md) under next version with high level changes in this PR.

# Usage
* For CDPO, simply set the model.dpo.label_smoothing to a positive non-zero value. For IPO, and KTO, set the model.dpo.preference_loss to "ipo" or "kto", respectively.

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? Make sure to also update the [NeMo Framework User Guide](https://docs.nvidia.com/nemo-framework/user-guide/latest/index.html) which contains the tutorials

# Checklist when contributing a new algorithm
- [x] Does the trainer resume and restore model state all states?
- [x] Does the trainer support all parallelism techniques(PP, TP, DP)?
- [x] Does the trainer support `max_steps=-1` and `validation`?
- [x] Does the trainer only call APIs defined in [alignable_interface.py](/nemo_aligner/models/alignable_interface.py)?
- [x] Does the trainer have proper logging?

# Additional Information
* Related to # (issue)
