### PR TITLE
Fix crash when using a separate reward model server in PPO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Fixed a potential issue when the base model's `model.data.data_prefix` config is a list and is about to be overridden with
 a dictionary from the training configuration.
 - `exp_manager.max_time_per_run` is now respected, the trainers will save and run validation before exiting if we've reached the time limit.
+- Fixed crash in PPO when using a separate reward model server (i.e., with `combine_rm_and_critic_server=False`).
 
 ## [0.1.0] - 2023-12-04
 ### Added


### PR DESCRIPTION
The problem was that PyTriton expects all outputs to have the same batch size, while the critic was returning a dummy length-1 tensor for rewards. It is cleaner to just not reeturn rewards at all.

@gshennvm should we add this setup to CI?