### PR TITLE
Add extra call to `clear_memory()` to fix OOM when sending critic data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### New features and optimizations
 - Added public-facing official Dockerfile for NeMo-Aligner
+- Memory optimization in PPO that helps avoid OOM in the actor when sending training data to the critic
 
 ### Breaking changes
 

--- a/nemo_aligner/algorithms/ppo.py
+++ b/nemo_aligner/algorithms/ppo.py
@@ -385,6 +385,7 @@ class PPOTrainer:
                 timing_metrics["rollout_time"] = self.timer.get("rollout_time")
 
                 # send critic train
+                clear_memory()
                 self.rm_critic.train(ppo_rollout_data)
 
                 # logging


### PR DESCRIPTION
# What does this PR do ?

Add extra call to `clear_memory()` to fix OOM when sending critic data

# Additional Information

For several weeks now I've been regularly running into
```
  File "/lustre/fs6/portfolios/llmservice/users/odelalleau/data/exp/rlhf/39-4c_ppo-43b-mb-hh-rm39-2-rkl1e-2-lr2e-7/NeMo-Aligner/examples/nlp/gpt/train_gpt_ppo_actor.py", line 175, in main
    ppo_trainer.fit()
  File "/lustre/fsw/portfolios/llmservice/users/odelalleau/data/exp/rlhf/39-4c_ppo-43b-mb-hh-rm39-2-rkl1e-2-lr2e-7/NeMo-Aligner/nemo_aligner/algorithms/ppo.py", line 388, in fit
    self.rm_critic.train(ppo_rollout_data)
  File "/lustre/fsw/portfolios/llmservice/users/odelalleau/data/exp/rlhf/39-4c_ppo-43b-mb-hh-rm39-2-rkl1e-2-lr2e-7/NeMo-Aligner/nemo_aligner/models/nlp/gpt/reward_critic_clients.py", line 150, in train
    send_data["tokens"] = func(ppo_rollout_data["response_tokens"], dtype=torch.int64)
  File "/lustre/fsw/portfolios/llmservice/users/odelalleau/data/exp/rlhf/39-4c_ppo-43b-mb-hh-rm39-2-rkl1e-2-lr2e-7/NeMo-Aligner/nemo_aligner/utils/distributed.py", line 41, in gather_tensor
    torch.distributed.gather(tensor, gather_list=gather_list, dst=dst, group=group)
  File "/usr/local/lib/python3.10/dist-packages/torch/distributed/c10d_logger.py", line 47, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/distributed/distributed_c10d.py", line 3071, in gather
    work = group.gather(output_tensors, input_tensors, opts)
RuntimeError: NCCL Error 1: unhandled cuda error (run with NCCL_DEBUG=INFO for details)
```
which, if you enable more NCCL bugs, is a CUDA OOM. This has always been surprising to me since this data is not particularly big, but adding a `clear_memory()` just before sending the data has always fixed it for me so I feel confident we should do it by default.