### PR TITLE
fix scheduler when not supplied

### DIFF
--- a/nemo_aligner/utils/train_script_utils.py
+++ b/nemo_aligner/utils/train_script_utils.py
@@ -104,15 +104,25 @@ def init_using_ptl(ptl_trainer, ptl_model, train_dataloader, train_ds):
     ptl_trainer._checkpoint_connector._restore_modules_and_callbacks(ptl_trainer.ckpt_path)
     ptl_trainer._checkpoint_connector.restore_training_state()
     ptl_trainer._checkpoint_connector.resume_end()
-    if ptl_model._scheduler is not None:
-        scheduler = ptl_model._scheduler["scheduler"]
+    scheduler = ptl_model.lr_schedulers()
 
+    if scheduler is not None:
         # restore the previous state of the learning rate
         if scheduler.last_epoch > 0:
             # NOTE: we are doing this because load_state_dict on a LRScheduler
             # does not do anything that restores the learning rate on the optimizer
             # stepping here will restore it properly
             scheduler.step(scheduler.last_epoch)
+
+
+class FakeScheduler:
+    def step(self):
+        ...
+
+
+class FakeCheckpointCallback:
+    def custom_save(self, *args, **kwargs):
+        ...
 
 
 def add_custom_checkpoint_callback(ptl_trainer, ptl_model):
@@ -124,15 +134,15 @@ def add_custom_checkpoint_callback(ptl_trainer, ptl_model):
             callback.custom_save = partial(callback.custom_save_ckpt_func, ptl_trainer, ptl_model)
             return callback
 
-    class FakeCheckpointCallback:
-        def custom_save(self, *args, **kwargs):
-            ...
-
     return FakeCheckpointCallback()
 
 
 def extract_optimizer_scheduler_from_ptl_model(ptl_model):
-    return ptl_model.optimizers().optimizer, ptl_model.lr_schedulers()
+    scheduler = ptl_model.lr_schedulers()
+    if scheduler is None:
+        scheduler = FakeScheduler()
+
+    return ptl_model.optimizers().optimizer, scheduler
 
 
 @dataclass


### PR DESCRIPTION
# What does this PR do ?

when user does not supply learning rate scheduler, nemo aligner will crash. but now we use a dummy scheduler object
