### PR TITLE
Fix random sampler keeping state with validation runs

### DIFF
--- a/examples/nlp/gpt/train_gpt_dpo.py
+++ b/examples/nlp/gpt/train_gpt_dpo.py
@@ -123,6 +123,7 @@ def main(cfg) -> None:
             reset_attention_mask=cfg.model.data.get("reset_attention_mask", False),
             eod_mask_loss=cfg.model.data.get("eod_mask_loss", False),
         ),
+        use_random_sampler=False
     )
 
     init_using_ptl(trainer, ptl_model, train_dataloader, train_ds)

--- a/examples/nlp/gpt/train_gpt_dpo.py
+++ b/examples/nlp/gpt/train_gpt_dpo.py
@@ -123,7 +123,7 @@ def main(cfg) -> None:
             reset_attention_mask=cfg.model.data.get("reset_attention_mask", False),
             eod_mask_loss=cfg.model.data.get("eod_mask_loss", False),
         ),
-        use_random_sampler=False
+        use_random_sampler=False,
     )
 
     init_using_ptl(trainer, ptl_model, train_dataloader, train_ds)

--- a/examples/nlp/gpt/train_gpt_ppo_actor.py
+++ b/examples/nlp/gpt/train_gpt_ppo_actor.py
@@ -130,7 +130,7 @@ def main(cfg) -> None:
         gbs=cfg.model.ppo.num_val_samples,
         collate_fn=collate_fn,
         load_gbs=False,
-        use_random_sampler=False
+        use_random_sampler=False,
     )
 
     # nemo uses the train dataloader to figure out

--- a/examples/nlp/gpt/train_gpt_ppo_actor.py
+++ b/examples/nlp/gpt/train_gpt_ppo_actor.py
@@ -130,6 +130,7 @@ def main(cfg) -> None:
         gbs=cfg.model.ppo.num_val_samples,
         collate_fn=collate_fn,
         load_gbs=False,
+        use_random_sampler=False
     )
 
     # nemo uses the train dataloader to figure out

--- a/examples/nlp/gpt/train_gpt_sft.py
+++ b/examples/nlp/gpt/train_gpt_sft.py
@@ -209,7 +209,7 @@ def main(cfg) -> None:
         drop_last=val_data_cfg.drop_last,
         pad_samples_to_global_batch_size=not val_data_cfg.drop_last,
         load_gbs=True,
-        use_random_sampler=False
+        use_random_sampler=False,
     )
 
     init_using_ptl(trainer, ptl_model, train_dataloader, train_ds)

--- a/examples/nlp/gpt/train_gpt_sft.py
+++ b/examples/nlp/gpt/train_gpt_sft.py
@@ -209,6 +209,7 @@ def main(cfg) -> None:
         drop_last=val_data_cfg.drop_last,
         pad_samples_to_global_batch_size=not val_data_cfg.drop_last,
         load_gbs=True,
+        use_random_sampler=False
     )
 
     init_using_ptl(trainer, ptl_model, train_dataloader, train_ds)

--- a/examples/nlp/gpt/train_reward_model.py
+++ b/examples/nlp/gpt/train_reward_model.py
@@ -122,7 +122,7 @@ def main(cfg) -> None:
         mbs=cfg.model.micro_batch_size,
         gbs=cfg.model.global_batch_size,
         load_gbs=True,
-        use_random_sampler=False
+        use_random_sampler=False,
     )
 
     init_using_ptl(trainer, ptl_model, train_dataloader, train_ds)

--- a/examples/nlp/gpt/train_reward_model.py
+++ b/examples/nlp/gpt/train_reward_model.py
@@ -122,6 +122,7 @@ def main(cfg) -> None:
         mbs=cfg.model.micro_batch_size,
         gbs=cfg.model.global_batch_size,
         load_gbs=True,
+        use_random_sampler=False
     )
 
     init_using_ptl(trainer, ptl_model, train_dataloader, train_ds)

--- a/nemo_aligner/data/nlp/builders.py
+++ b/nemo_aligner/data/nlp/builders.py
@@ -342,14 +342,12 @@ def build_dataloader(
     if hasattr(cfg.model.data, "dataloader_type") and cfg.model.data.dataloader_type == "single":
         if use_random_sampler:
             cls = MegatronPretrainingRandomBatchSampler if load_gbs else MegatronPretrainingRandomSampler
-            common_params['seed'] = cfg.model.seed
+            common_params["seed"] = cfg.model.seed
         else:
             cls = MegatronPretrainingBatchSampler if load_gbs else MegatronPretrainingSampler
         batch_sampler = cls(**common_params)
     else:
-        raise ValueError(
-            '`cfg.model.data.dataloader_type` must be set to "single"'
-        )
+        raise ValueError('`cfg.model.data.dataloader_type` must be set to "single"')
 
     return torch.utils.data.DataLoader(
         dataset,

--- a/nemo_aligner/data/nlp/builders.py
+++ b/nemo_aligner/data/nlp/builders.py
@@ -352,7 +352,7 @@ def build_dataloader(
         batch_sampler = create_batch_sampler(cls, **common_params, seed=cfg.model.seed if use_random_sampler else None)
     else:
         raise ValueError(
-            'cfg.model.data.dataloader_type must be "single" or cfg.model.data.dataloader_type not found.'
+            'cfg.model.data.dataloader_type` must be set to "single"
         )
 
     return torch.utils.data.DataLoader(

--- a/nemo_aligner/data/nlp/builders.py
+++ b/nemo_aligner/data/nlp/builders.py
@@ -321,7 +321,7 @@ def build_dataloader(
     pad_samples_to_global_batch_size=False,
     collate_fn=None,
     load_gbs=True,
-    use_random_sampler=True
+    use_random_sampler=True,
 ):
     """Buld dataloader given an input dataset."""
 
@@ -332,14 +332,14 @@ def build_dataloader(
     logging.info(f"Building dataloader with consumed samples: {consumed_samples}")
     # Common parameters for batch sampler creation
     common_params = {
-        'total_samples': len(dataset),
-        'consumed_samples': consumed_samples,
-        'micro_batch_size': mbs,
-        'data_parallel_rank': parallel_state.get_data_parallel_rank(),
-        'data_parallel_size': parallel_state.get_data_parallel_world_size(),
-        'drop_last': drop_last,
-        'global_batch_size': gbs,
-        'pad_samples_to_global_batch_size': pad_samples_to_global_batch_size,
+        "total_samples": len(dataset),
+        "consumed_samples": consumed_samples,
+        "micro_batch_size": mbs,
+        "data_parallel_rank": parallel_state.get_data_parallel_rank(),
+        "data_parallel_size": parallel_state.get_data_parallel_world_size(),
+        "drop_last": drop_last,
+        "global_batch_size": gbs,
+        "pad_samples_to_global_batch_size": pad_samples_to_global_batch_size,
     }
 
     # Megatron sampler
@@ -351,7 +351,9 @@ def build_dataloader(
 
         batch_sampler = create_batch_sampler(cls, **common_params, seed=cfg.model.seed if use_random_sampler else None)
     else:
-        raise ValueError('cfg.model.data.dataloader_type must be "single" or cfg.model.data.dataloader_type not found.')
+        raise ValueError(
+            'cfg.model.data.dataloader_type must be "single" or cfg.model.data.dataloader_type not found.'
+        )
 
     return torch.utils.data.DataLoader(
         dataset,

--- a/nemo_aligner/data/nlp/builders.py
+++ b/nemo_aligner/data/nlp/builders.py
@@ -325,10 +325,6 @@ def build_dataloader(
 ):
     """Buld dataloader given an input dataset."""
 
-    def create_batch_sampler(cls, **kwargs):
-        """Helper function to create a batch sampler."""
-        return cls(**kwargs)
-
     logging.info(f"Building dataloader with consumed samples: {consumed_samples}")
     # Common parameters for batch sampler creation
     common_params = {
@@ -346,10 +342,10 @@ def build_dataloader(
     if hasattr(cfg.model.data, "dataloader_type") and cfg.model.data.dataloader_type == "single":
         if use_random_sampler:
             cls = MegatronPretrainingRandomBatchSampler if load_gbs else MegatronPretrainingRandomSampler
+            common_params['seed'] = cfg.model.seed
         else:
-            cls = MegatronPretrainingSampler
-
-        batch_sampler = create_batch_sampler(cls, **common_params, seed=cfg.model.seed if use_random_sampler else None)
+            cls = MegatronPretrainingBatchSampler if load_gbs else MegatronPretrainingSampler
+        batch_sampler = cls(**common_params)
     else:
         raise ValueError(
             'cfg.model.data.dataloader_type` must be set to "single"

--- a/nemo_aligner/data/nlp/builders.py
+++ b/nemo_aligner/data/nlp/builders.py
@@ -348,7 +348,7 @@ def build_dataloader(
         batch_sampler = cls(**common_params)
     else:
         raise ValueError(
-            'cfg.model.data.dataloader_type` must be set to "single"
+            '`cfg.model.data.dataloader_type` must be set to "single"'
         )
 
     return torch.utils.data.DataLoader(


### PR DESCRIPTION
Fixes issue #107 by allowing having `build_dataloader` support both deterministic and random samplers, and revert PPO `val_dataloader` to be a deterministic one, thus allowing tracking the same batch during a PPO run. 

The same issue seems to also be present with DPO. Is the expected behavior same as with PPO and we'd like to use a deterministic batch sampler with DPO as well? 

