### PR TITLE
Restore shuffling of the validation set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Breaking changes
 
 ### Bug Fixes
-- Fixed issue where random sampler keeps state when resetting for validation, leading to a different validation batch each validation step. Fixed by using a deterministic sampler
+- Fixed issue where random sampler keeps state when resetting for validation, leading to different validation data each validation step (when not going over the full validation set, which is the case by default in PPO for instance)
 - Fixed crash with float val check interval in DPOTrainer
 
 ## [0.2.0] - 2024-02

--- a/examples/nlp/gpt/train_gpt_dpo.py
+++ b/examples/nlp/gpt/train_gpt_dpo.py
@@ -123,7 +123,6 @@ def main(cfg) -> None:
             reset_attention_mask=cfg.model.data.get("reset_attention_mask", False),
             eod_mask_loss=cfg.model.data.get("eod_mask_loss", False),
         ),
-        auto_update_consumed_samples=False,
     )
 
     init_using_ptl(trainer, ptl_model, train_dataloader, train_ds)

--- a/examples/nlp/gpt/train_gpt_dpo.py
+++ b/examples/nlp/gpt/train_gpt_dpo.py
@@ -123,7 +123,7 @@ def main(cfg) -> None:
             reset_attention_mask=cfg.model.data.get("reset_attention_mask", False),
             eod_mask_loss=cfg.model.data.get("eod_mask_loss", False),
         ),
-        use_random_sampler=False,
+        auto_update_consumed_samples=False,
     )
 
     init_using_ptl(trainer, ptl_model, train_dataloader, train_ds)

--- a/examples/nlp/gpt/train_gpt_ppo_actor.py
+++ b/examples/nlp/gpt/train_gpt_ppo_actor.py
@@ -130,7 +130,7 @@ def main(cfg) -> None:
         gbs=cfg.model.ppo.num_val_samples,
         collate_fn=collate_fn,
         load_gbs=False,
-        use_random_sampler=False,
+        auto_update_consumed_samples=False,
     )
 
     # nemo uses the train dataloader to figure out

--- a/examples/nlp/gpt/train_gpt_ppo_actor.py
+++ b/examples/nlp/gpt/train_gpt_ppo_actor.py
@@ -130,7 +130,6 @@ def main(cfg) -> None:
         gbs=cfg.model.ppo.num_val_samples,
         collate_fn=collate_fn,
         load_gbs=False,
-        auto_update_consumed_samples=False,
     )
 
     # nemo uses the train dataloader to figure out

--- a/examples/nlp/gpt/train_gpt_sft.py
+++ b/examples/nlp/gpt/train_gpt_sft.py
@@ -209,7 +209,6 @@ def main(cfg) -> None:
         drop_last=val_data_cfg.drop_last,
         pad_samples_to_global_batch_size=not val_data_cfg.drop_last,
         load_gbs=True,
-        auto_update_consumed_samples=False,
     )
 
     init_using_ptl(trainer, ptl_model, train_dataloader, train_ds)

--- a/examples/nlp/gpt/train_gpt_sft.py
+++ b/examples/nlp/gpt/train_gpt_sft.py
@@ -209,7 +209,7 @@ def main(cfg) -> None:
         drop_last=val_data_cfg.drop_last,
         pad_samples_to_global_batch_size=not val_data_cfg.drop_last,
         load_gbs=True,
-        use_random_sampler=False,
+        auto_update_consumed_samples=False,
     )
 
     init_using_ptl(trainer, ptl_model, train_dataloader, train_ds)

--- a/examples/nlp/gpt/train_reward_model.py
+++ b/examples/nlp/gpt/train_reward_model.py
@@ -122,7 +122,6 @@ def main(cfg) -> None:
         mbs=cfg.model.micro_batch_size,
         gbs=cfg.model.global_batch_size,
         load_gbs=True,
-        auto_update_consumed_samples=False,
     )
 
     init_using_ptl(trainer, ptl_model, train_dataloader, train_ds)

--- a/examples/nlp/gpt/train_reward_model.py
+++ b/examples/nlp/gpt/train_reward_model.py
@@ -122,7 +122,7 @@ def main(cfg) -> None:
         mbs=cfg.model.micro_batch_size,
         gbs=cfg.model.global_batch_size,
         load_gbs=True,
-        use_random_sampler=False,
+        auto_update_consumed_samples=False,
     )
 
     init_using_ptl(trainer, ptl_model, train_dataloader, train_ds)

--- a/nemo_aligner/algorithms/ppo.py
+++ b/nemo_aligner/algorithms/ppo.py
@@ -351,12 +351,13 @@ class PPOTrainer:
         if (not isinstance(self.train_dataloader.batch_sampler, MegatronPretrainingRandomSampler)) and (
             self.cfg.max_epochs is not None and self.cfg.max_epochs > 1
         ):
-            # if you use MegatronPretrainingBatchSampler as the batch_sampler passed to your train dataloader (in builders.py)
+            # if you use MegatronPretrainingSampler as the sampler passed to your train dataloader (in builders.py)
             # then each epoch will repeat all your samples in the same order as the previous epoch, there is no shuffling
             # to fix this, you should use MegatronPretrainingRandomSampler instead, which alleviates this issue and allows
             # random shuffling for each epoch.
             raise ValueError(
-                "max_epochs > 1 is not supported unless using `MegatronPretrainingRandomSampler` as the batch_sampler for your train dataloader"
+                "max_epochs > 1 is not supported unless using `MegatronPretrainingRandomSampler` as the sampler "
+                "for your train dataloader"
             )
 
         epoch_iter = range(self.epoch, self.cfg.max_epochs)

--- a/nemo_aligner/algorithms/ppo.py
+++ b/nemo_aligner/algorithms/ppo.py
@@ -38,7 +38,7 @@ from nemo_aligner.utils.ppo_utils import (
 )
 from nemo_aligner.utils.server_utils import FutureResult
 from nemo_aligner.utils.train_utils import clip_gradients
-from nemo_aligner.utils.trainer_utils import check_progress, compute_num_steps_per_epoch
+from nemo_aligner.utils.trainer_utils import check_progress, compute_num_steps_per_epoch, set_consumed_samples
 from nemo_aligner.utils.utils import clear_memory, cpu_dict, masked_mean
 
 
@@ -86,7 +86,7 @@ class PPOTrainer:
         self.ppo_optimization_step = 0
 
         # compute `max_steps`
-        self.num_steps_per_epoch = compute_num_steps_per_epoch(self.train_dataloader.batch_sampler)
+        self.num_steps_per_epoch = compute_num_steps_per_epoch(self.train_dataloader)
         self.set_max_steps()
 
         self.compute_init_policy_kl = self.cfg.initial_policy_kl_penalty > 0
@@ -374,6 +374,7 @@ class PPOTrainer:
             if not loop_iter:
                 return  # training ended
 
+            set_consumed_samples(self.train_dataloader, self.consumed_samples)
             dataloader_iter = iter(self.train_dataloader)
 
             global_pbar = tqdm(loop_iter, initial=self.step, total=self.max_steps, leave=True, desc="PPO Global Step")

--- a/nemo_aligner/algorithms/supervised.py
+++ b/nemo_aligner/algorithms/supervised.py
@@ -26,7 +26,12 @@ from nemo.utils import logging
 from nemo_aligner.metrics import InferenceMetricsHandler
 from nemo_aligner.utils.distributed import SyncTimer
 from nemo_aligner.utils.train_utils import clip_gradients
-from nemo_aligner.utils.trainer_utils import check_progress, compute_limit_batches, compute_num_steps_per_epoch
+from nemo_aligner.utils.trainer_utils import (
+    check_progress,
+    compute_limit_batches,
+    compute_num_steps_per_epoch,
+    set_consumed_samples,
+)
 
 
 class SupervisedTrainer:
@@ -65,7 +70,7 @@ class SupervisedTrainer:
         self.ckpt_callback = ckpt_callback
 
         # compute `max_steps`
-        self.num_steps_per_epoch = compute_num_steps_per_epoch(self.train_dataloader.batch_sampler)
+        self.num_steps_per_epoch = compute_num_steps_per_epoch(self.train_dataloader)
 
         self.limit_val_batches = compute_limit_batches(len(val_dataloader), self.cfg.limit_val_batches)
         self.set_max_steps()
@@ -176,6 +181,7 @@ class SupervisedTrainer:
             if not loop_iter:
                 return  # training ended
 
+            set_consumed_samples(self.train_dataloader, self.consumed_samples)
             global_pbar = tqdm(
                 self.train_dataloader, initial=self.step, total=self.max_steps, leave=True, desc="Training steps"
             )

--- a/nemo_aligner/data/nlp/builders.py
+++ b/nemo_aligner/data/nlp/builders.py
@@ -319,7 +319,6 @@ def build_dataloader(
     pad_samples_to_global_batch_size=False,
     collate_fn=None,
     load_gbs=True,
-    auto_update_consumed_samples=True,
 ):
     """Buld dataloader given an input dataset."""
 
@@ -328,7 +327,7 @@ def build_dataloader(
     sampler_params = {
         "total_samples": len(dataset),
         "consumed_samples": consumed_samples,
-        "auto_update_consumed_samples": auto_update_consumed_samples,
+        "auto_update_consumed_samples": False,
         "micro_batch_size": mbs,
         "data_parallel_rank": parallel_state.get_data_parallel_rank(),
         "data_parallel_size": parallel_state.get_data_parallel_world_size(),

--- a/nemo_aligner/data/nlp/builders.py
+++ b/nemo_aligner/data/nlp/builders.py
@@ -30,14 +30,12 @@ from nemo.collections.nlp.data.language_modeling.megatron.base_dataset_utils imp
     get_train_valid_test_split_,
 )
 from nemo.collections.nlp.data.language_modeling.megatron.blendable_dataset import BlendableDataset
-
 from nemo.collections.nlp.data.language_modeling.megatron.data_samplers import MegatronPretrainingSampler
 from nemo.collections.nlp.data.language_modeling.megatron.gpt_dataset import get_indexed_dataset_
 from nemo.collections.nlp.data.language_modeling.megatron.gpt_sft_chat_dataset import GPTSFTChatDataset
 from nemo.collections.nlp.data.language_modeling.megatron.gpt_sft_dataset import GPTSFTDataset
 from nemo.collections.nlp.data.language_modeling.megatron.megatron_batch_samplers import (
     MegatronPretrainingBatchSampler,
-    MegatronPretrainingRandomBatchSampler,
 )
 from nemo.utils import logging
 from nemo_aligner.data.nlp.datasets import (
@@ -46,7 +44,7 @@ from nemo_aligner.data.nlp.datasets import (
     RewardModelDataset,
     RLHFDataset,
 )
-from nemo_aligner.data.nlp.samplers import MegatronPretrainingRandomSampler
+from nemo_aligner.data.nlp.samplers import MegatronPretrainingRandomBatchSampler, MegatronPretrainingRandomSampler
 from nemo_aligner.utils.utils import collate_with_batch_max_sequence_length
 
 
@@ -321,31 +319,29 @@ def build_dataloader(
     pad_samples_to_global_batch_size=False,
     collate_fn=None,
     load_gbs=True,
-    use_random_sampler=True,
+    auto_update_consumed_samples=True,
 ):
     """Buld dataloader given an input dataset."""
 
     logging.info(f"Building dataloader with consumed samples: {consumed_samples}")
-    # Common parameters for batch sampler creation
-    common_params = {
+
+    sampler_params = {
         "total_samples": len(dataset),
         "consumed_samples": consumed_samples,
+        "auto_update_consumed_samples": auto_update_consumed_samples,
         "micro_batch_size": mbs,
         "data_parallel_rank": parallel_state.get_data_parallel_rank(),
         "data_parallel_size": parallel_state.get_data_parallel_world_size(),
         "drop_last": drop_last,
         "global_batch_size": gbs,
         "pad_samples_to_global_batch_size": pad_samples_to_global_batch_size,
+        "seed": cfg.model.seed,
     }
 
     # Megatron sampler
     if hasattr(cfg.model.data, "dataloader_type") and cfg.model.data.dataloader_type == "single":
-        if use_random_sampler:
-            cls = MegatronPretrainingRandomBatchSampler if load_gbs else MegatronPretrainingRandomSampler
-            common_params["seed"] = cfg.model.seed
-        else:
-            cls = MegatronPretrainingBatchSampler if load_gbs else MegatronPretrainingSampler
-        batch_sampler = cls(**common_params)
+        cls = MegatronPretrainingRandomBatchSampler if load_gbs else MegatronPretrainingRandomSampler
+        batch_sampler = cls(**sampler_params)
     else:
         raise ValueError('`cfg.model.data.dataloader_type` must be set to "single"')
 

--- a/nemo_aligner/data/nlp/samplers.py
+++ b/nemo_aligner/data/nlp/samplers.py
@@ -13,18 +13,17 @@
 # limitations under the License.
 
 
-from itertools import chain
 from typing import Optional
 
 import torch
 
+from nemo.collections.nlp.data.language_modeling.megatron import megatron_batch_samplers
 from nemo.collections.nlp.data.language_modeling.megatron.data_samplers import BaseMegatronSampler
-
-from nemo.utils import logging
 
 
 # this class is meant to be temporary until NeMo upstream merges in https://github.com/NVIDIA/NeMo/pull/8239
 # once that PR is merged, we can delete this class (and file) and just use the NeMo class instead
+# TODO the NeMo version will also need to be updated to include `auto_update_consumed_samples`.
 class MegatronPretrainingRandomSampler(BaseMegatronSampler):
     def __init__(
         self,
@@ -37,6 +36,7 @@ class MegatronPretrainingRandomSampler(BaseMegatronSampler):
         global_batch_size: Optional[int] = None,
         pad_samples_to_global_batch_size: Optional[bool] = False,
         seed: int = 0,
+        auto_update_consumed_samples: bool = True,
     ) -> None:
         super().__init__(
             total_samples=total_samples,
@@ -58,6 +58,7 @@ class MegatronPretrainingRandomSampler(BaseMegatronSampler):
             )
         self.last_batch_size = self.total_samples % self.micro_batch_times_data_parallel_size
         self.seed = seed
+        self.auto_update_consumed_samples = auto_update_consumed_samples
 
     def __len__(self):
         active_total_samples = self.total_samples - (self.last_batch_size if self.drop_last else 0)
@@ -94,10 +95,48 @@ class MegatronPretrainingRandomSampler(BaseMegatronSampler):
         for idx in idx_range:
             batch.append(idx)
             if len(batch) == self.micro_batch_size:
-                self.consumed_samples += self.micro_batch_times_data_parallel_size
+                if self.auto_update_consumed_samples:
+                    self.consumed_samples += self.micro_batch_times_data_parallel_size
                 yield batch
                 batch = []
 
+        # Check the last partial batch and see drop_last is set
+        if len(batch) > 0 and not self.drop_last:
+            yield batch
+
+
+# this class is also meant to be removed once the `auto_update_consumed_samples` is upstreamed into NeMo.
+class MegatronPretrainingRandomBatchSampler(megatron_batch_samplers.MegatronPretrainingRandomBatchSampler):
+    def __init__(self, *args, auto_update_consumed_samples: bool = True, **kw):
+        super().__init__(*args, **kw)
+        self.auto_update_consumed_samples = auto_update_consumed_samples
+
+    # This is just a copy of the parent class' `__iter__()` method, but also handling `auto_update_consumed_samples`.
+    def __iter__(self):
+        active_total_samples = self.total_samples - self.last_batch_size
+        self.epoch = self.consumed_samples // active_total_samples
+        current_epoch_samples = self.consumed_samples % active_total_samples
+        assert current_epoch_samples % self.micro_batch_times_data_parallel_size == 0
+
+        # data sharding and random sampling
+        bucket_size = (self.total_samples // self.micro_batch_times_data_parallel_size) * self.micro_batch_size
+        bucket_offset = current_epoch_samples // self.data_parallel_size
+        start_idx = self.data_parallel_rank * bucket_size
+
+        g = torch.Generator()
+        g.manual_seed(self.seed + self.epoch)
+        random_idx = torch.randperm(bucket_size, generator=g).tolist()
+        idx_range = [start_idx + x for x in random_idx[bucket_offset:]]
+
+        batch = []
+        # Last batch if not complete will be dropped.
+        for idx in idx_range:
+            batch.append(idx)
+            if len(batch) == self._global_batch_size_on_this_data_parallel_rank:
+                if self.auto_update_consumed_samples:
+                    self.consumed_samples += self._global_batch_size
+                yield batch
+                batch = []
         # Check the last partial batch and see drop_last is set
         if len(batch) > 0 and not self.drop_last:
             yield batch

--- a/nemo_aligner/utils/trainer_utils.py
+++ b/nemo_aligner/utils/trainer_utils.py
@@ -14,19 +14,20 @@
 
 from typing import Union
 
-from nemo.collections.nlp.data.language_modeling.megatron.megatron_batch_samplers import (
-    MegatronPretrainingRandomBatchSampler,
-)
-from nemo_aligner.data.nlp.samplers import MegatronPretrainingRandomSampler
+import torch
 
 
-def compute_num_steps_per_epoch(
-    sampler: Union[MegatronPretrainingRandomSampler, MegatronPretrainingRandomBatchSampler]
-):
+def compute_num_steps_per_epoch(dataloader: torch.utils.data.DataLoader) -> int:
+    sampler = dataloader.batch_sampler
     if not sampler.drop_last:
         raise NotImplementedError("`drop_last=False` is not currently supported")
 
     return sampler.total_samples // sampler.global_batch_size
+
+
+def set_consumed_samples(dataloader: torch.utils.data.DataLoader, consumed_samples: int) -> None:
+    sampler = dataloader.batch_sampler
+    sampler.consumed_samples = consumed_samples
 
 
 def compute_limit_batches(number_of_batches: int, limit_batches: Union[int, float, None]):


### PR DESCRIPTION
# What does this PR do ?

This is a follow-up to https://github.com/NVIDIA/NeMo-Aligner/pull/112#discussion_r1506600054 to restore the shuffling of the validation set.

I implemented two versions and would appreciate feedback from @gshennvm / @gleibovich-nvidia / @trias702 on what you all prefer:
- v1 (first commit 2b245502) is the more "minimal" version
- v2 (second commit 1c02cdd6) enforces setting `consumed_samples` in the trainer manually

Personally I have a slight preference for v2 because I prefer explicit to implicit -- the implicit update of `consumed_samples` in the sampler can be dangerous (as we've experienced), and also leads to a weird behavior where the `len()` of the sampler decreases as we iterate over it (which is quite unusual for objects we typically iterate on). I realize however that this adds an extra line to the trainers and diverges from what happens within NeMo, so I'm ok with v1 as well if I'm in the minority here.

I will also add the sister PR to NeMo but I want to get some feedback first to decide on the final implementation.

(currently marked as draft until we agree and I properly test this, but please do provide feedback now)