### PR TITLE
SPIN bug fix for prompt lengths being greater than generation.max_length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Fixed issue where random sampler keeps state when resetting for validation, leading to a different validation batch each validation step. Fixed by using a deterministic sampler
 - Fixed crash with float val check interval in DPOTrainer
 - Fixed crash with float val check interval when checking progress in DPOTrainer
+- Fixed potential crash in SPIN when prompts are longer than encoder_seq_len - generation.max_length
 
 ## [0.2.0] - 2024-02
 ### New features and optimizations

--- a/nemo_aligner/algorithms/spin.py
+++ b/nemo_aligner/algorithms/spin.py
@@ -201,6 +201,10 @@ class SPINTrainer:
         prompt_lengths = batch["prompt_lengths"]
         batch_max_length = prompt_lengths.max().item()
         max_possible_length = min(self.model.cfg.encoder_seq_length, batch_max_length + self.max_gen_seq_len)
+        # in case the prompt length exceeds encoder_seq_length - max_gen_seq_len, we need to truncate how many
+        # tokens we are allowed to generate such that we never exceed encoder_seq_length, otherwise you will get
+        # errors inside model.generate()
+        adj_generation_length = min(self.max_gen_seq_len, self.model.cfg.encoder_seq_length - batch_max_length)
 
         prompt_tokens = batch_pad_to_fixed_len(
             batch["prompts_only"], max_possible_length, pad_token=self.model.tokenizer.eos_id
@@ -209,11 +213,11 @@ class SPINTrainer:
         prompt_lengths = prompt_lengths.cuda(non_blocking=True)
 
         strategy = TrackLengthGPTModelTextGenerationStrategy(
-            model=self.model, context_lengths=prompt_lengths, max_length=self.max_gen_seq_len
+            model=self.model, context_lengths=prompt_lengths, max_length=adj_generation_length
         )
         generations = self.model.generate(
             inputs=(prompt_tokens, prompt_lengths),
-            length_params=self.length_params,
+            length_params=self.length_params | {'max_length': adj_generation_length},
             sampling_params=self.sampling_params,
             strategy=strategy,
         )
@@ -231,7 +235,7 @@ class SPINTrainer:
             # and remove the `if` below.
             if (
                 max_response_length >= response_tokens.size(1)
-                or response_tokens.size(1) != prompt_lengths.max().item() + self.max_gen_seq_len
+                or response_tokens.size(1) != batch_max_length + adj_generation_length
             ):
                 raise AssertionError(
                     f"max response length ({max_response_length}) does not match the size of "

--- a/nemo_aligner/algorithms/spin.py
+++ b/nemo_aligner/algorithms/spin.py
@@ -217,7 +217,7 @@ class SPINTrainer:
         )
         generations = self.model.generate(
             inputs=(prompt_tokens, prompt_lengths),
-            length_params=self.length_params | {'max_length': adj_generation_length},
+            length_params=self.length_params | {"max_length": adj_generation_length},
             sampling_params=self.sampling_params,
             strategy=strategy,
         )


### PR DESCRIPTION
# What does this PR do ?

Fixes an error in SPIN if you get samples where the prompt length exceeds the model's max seq length minus your generation.max_length

# Changelog 
- Please update the [CHANGELOG.md](/CHANGELOG.md) under next version with high level changes in this PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? Make sure to also update the [NeMo Framework User Guide](https://docs.nvidia.com/nemo-framework/user-guide/latest/index.html) which contains the tutorials

# Checklist when contributing a new algorithm
- [ ] Does the trainer resume and restore model state all states?
- [ ] Does the trainer support all parallelism techniques(PP, TP, DP)?
- [ ] Does the trainer support `max_steps=-1` and `validation`?
- [ ] Does the trainer only call APIs defined in [alignable_interface.py](/nemo_aligner/models/alignable_interface.py)?
- [ ] Does the trainer have proper logging?

# Additional Information
* Related to # (issue)
