### PR TITLE
SPIN generation batch size is now configurable as a hyperparameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Added the ability to do multi-epoch (cfg.max_epochs > 1) training for reward models, DPO, PPO, and SFT
 - Added the SPIN (Self-Play Fine Tuning) algorithm (https://arxiv.org/abs/2401.01335) which allows SPIN SFT training using SFT-format dataset files
 - SFT/SteerLM: added LoRA tuning as an option besides full fine-tuning, only attention_qkv layer is supported
+- SPIN: added `generation_batch_size` parameter which allows users to set the batch size for doing generation during SPIN training.
+        previously the generation batch size was automatically set to the data parallel size (DP) of the model
 
 ### Breaking changes
 - We have changed the shuffle logic in the data sampler to support multi-epoch training, so training runs using identical parameters

--- a/examples/nlp/gpt/conf/gpt_spin.yaml
+++ b/examples/nlp/gpt/conf/gpt_spin.yaml
@@ -61,6 +61,7 @@ model:
 
   spin:
     log_prob_forward_micro_batch_size: 1
+    generation_batch_size: 16
     ref_policy_kl_penalty: 0.2   # Can also be a list of elements == max_iterations, where each element will be the KL penalty used for that iteration
     offload_adam_states: True
 

--- a/nemo_aligner/algorithms/spin.py
+++ b/nemo_aligner/algorithms/spin.py
@@ -127,6 +127,7 @@ class SPINTrainer:
         self.length_params = OmegaConf.to_container(self.model.cfg.spin.length_params, resolve=True)
         self.sampling_params = OmegaConf.to_container(self.model.cfg.spin.sampling_params, resolve=True)
         self.max_gen_seq_len = self.length_params["max_length"]
+        self.gen_batch_size = self.model.cfg.spin.generation_batch_size
 
     def validation_step(self, global_batch):
         # these things should go into a GPTModel wrapper
@@ -195,10 +196,10 @@ class SPINTrainer:
         return loss_mean, {**metrics, **trainer_metrics}
 
     @torch.no_grad()
-    def get_generations(self, batch):
+    def get_generations(self, list_of_batches):
         self.model.prepare_for_inference()
 
-        prompt_lengths = batch["prompt_lengths"]
+        prompt_lengths = torch.cat([b["prompt_lengths"] for b in list_of_batches], dim=0)
         batch_max_length = prompt_lengths.max().item()
         max_possible_length = min(self.model.cfg.encoder_seq_length, batch_max_length + self.max_gen_seq_len)
         # in case the prompt length exceeds encoder_seq_length - max_gen_seq_len, we need to truncate how many
@@ -206,9 +207,7 @@ class SPINTrainer:
         # errors inside model.generate()
         adj_generation_length = min(self.max_gen_seq_len, self.model.cfg.encoder_seq_length - batch_max_length)
 
-        prompt_tokens = batch_pad_to_fixed_len(
-            batch["prompts_only"], max_possible_length, pad_token=self.model.tokenizer.eos_id
-        )
+        prompt_tokens = torch.cat([batch_pad_to_fixed_len(b["prompts_only"], max_possible_length, pad_token=self.model.tokenizer.eos_id) for b in list_of_batches], dim=0)
         prompt_tokens = prompt_tokens.cuda(non_blocking=True)
         prompt_lengths = prompt_lengths.cuda(non_blocking=True)
 
@@ -405,65 +404,80 @@ class SPINTrainer:
     def augment_dataloader(self, dataloader):
         """Augment dataloader with generations and ref policy log probs"""
         iter_dataloader = iter(dataloader)
+        buffer = []
         done = False
         while not done:
             try:
                 batch = next(iter_dataloader)
-
+            except StopIteration:
+                done = True
+            else:
+                buffer.append(batch)
+            if (done and buffer) or len(buffer) == self.gen_batch_size:
                 # generations use the reference model weights, as per the paper
                 with cpu_weight_swap(
                     self.model, self.model.ref_policy_state_dict, megatron_amp_O2=self.model.megatron_amp_O2
                 ):
                     # Generation happens on GPU but the returned tensors are on CPU.
-                    gen_tokens, gen_lengths = self.get_generations(batch)
-                act_tokens = batch["prompts_and_answers"]
-                act_lengths = batch["combined_lengths"]
-                max_batch_len = max(act_tokens.shape[1], gen_tokens.shape[1])
-
-                act_tokens_pad = batch_pad_to_fixed_len(
-                    act_tokens, max_batch_len, pad_token=self.model.tokenizer.eos_id
-                )
-                gen_tokens_pad = batch_pad_to_fixed_len(
-                    gen_tokens, max_batch_len, pad_token=self.model.tokenizer.eos_id
-                )
-
-                act_mask = create_mask(act_tokens_pad, batch["prompt_lengths"], act_lengths)
-                gen_mask = create_mask(gen_tokens_pad, batch["prompt_lengths"], gen_lengths)
-
-                attention_mask, _, position_ids = get_ltor_masks_and_position_ids(
-                    act_tokens_pad,
-                    self.model.tokenizer.eos_id,
-                    self.model.cfg.data.reset_position_ids,
-                    self.model.cfg.data.reset_attention_mask,
-                    self.model.cfg.data.eod_mask_loss,
-                )
-                assert attention_mask.ndim == 4, "attention_mask is incorrect shape"
-                if attention_mask.shape[0] == 1:
-                    # using .expand() here causes errors from pin_memory=True, so need to use .repeat()
-                    # attention_mask = attention_mask.expand(len(act_tokens_pad), *((-1,) * (len(attention_mask.shape) - 1)))
-                    attention_mask = attention_mask.repeat(
-                        len(act_tokens_pad), *((1,) * (len(attention_mask.shape) - 1))
+                    gen_tokens_buf, gen_lengths_buf = self.get_generations(buffer)
+                
+                start = 0
+                for batch in buffer:
+                    batch_size = len(batch["prompts_and_answers"])
+                    
+                    gen_tokens = gen_tokens_buf[start : start + batch_size]
+                    gen_lengths = gen_lengths_buf[start : start + batch_size]
+                    
+                    act_tokens = batch["prompts_and_answers"]
+                    act_lengths = batch["combined_lengths"]
+                    max_batch_len = max(act_tokens.shape[1], gen_tokens.shape[1])
+    
+                    act_tokens_pad = batch_pad_to_fixed_len(
+                        act_tokens, max_batch_len, pad_token=self.model.tokenizer.eos_id
                     )
+                    gen_tokens_pad = batch_pad_to_fixed_len(
+                        gen_tokens, max_batch_len, pad_token=self.model.tokenizer.eos_id
+                    )
+    
+                    act_mask = create_mask(act_tokens_pad, batch["prompt_lengths"], act_lengths)
+                    gen_mask = create_mask(gen_tokens_pad, batch["prompt_lengths"], gen_lengths)
+    
+                    attention_mask, _, position_ids = get_ltor_masks_and_position_ids(
+                        act_tokens_pad,
+                        self.model.tokenizer.eos_id,
+                        self.model.cfg.data.reset_position_ids,
+                        self.model.cfg.data.reset_attention_mask,
+                        self.model.cfg.data.eod_mask_loss,
+                    )
+                    assert attention_mask.ndim == 4, "attention_mask is incorrect shape"
+                    if attention_mask.shape[0] == 1:
+                        # using .expand() here causes errors from pin_memory=True, so need to use .repeat()
+                        # attention_mask = attention_mask.expand(len(act_tokens_pad), *((-1,) * (len(attention_mask.shape) - 1)))
+                        attention_mask = attention_mask.repeat(
+                            len(act_tokens_pad), *((1,) * (len(attention_mask.shape) - 1))
+                        )
+    
+                    new_batch = {}
+                    new_batch["actual"] = act_tokens_pad
+                    new_batch["generated"] = gen_tokens_pad
+                    new_batch["attention_mask"] = attention_mask
+                    new_batch["position_ids"] = position_ids
+                    new_batch["actual_mask"] = act_mask
+                    new_batch["generated_mask"] = gen_mask
+    
+                    logprobs = self.model.get_ref_policy_logprobs(new_batch).cpu()
+                    act_logps, gen_logps = torch.split(logprobs, len(logprobs) // 2, dim=0)
+    
+                    new_batch["ref_policy_log_probs_actual"] = act_logps
+                    new_batch["ref_policy_log_probs_generated"] = gen_logps
 
-                new_batch = {}
-                new_batch["actual"] = act_tokens_pad
-                new_batch["generated"] = gen_tokens_pad
-                new_batch["attention_mask"] = attention_mask
-                new_batch["position_ids"] = position_ids
-                new_batch["actual_mask"] = act_mask
-                new_batch["generated_mask"] = gen_mask
+                    start += batch_size
+                    
+                    yield new_batch
 
-                logprobs = self.model.get_ref_policy_logprobs(new_batch).cpu()
-                act_logps, gen_logps = torch.split(logprobs, len(logprobs) // 2, dim=0)
-
-                new_batch["ref_policy_log_probs_actual"] = act_logps
-                new_batch["ref_policy_log_probs_generated"] = gen_logps
-
-                yield new_batch
-
+                buffer.clear()
                 del logprobs, act_logps, gen_logps, new_batch
-            except StopIteration:
-                done = True
+
 
     @property
     def epoch(self):


### PR DESCRIPTION
# What does this PR do ?

Adds a hyperparameter to SPIN which allows users to set the generation batch size

# Changelog 
- Please update the [CHANGELOG.md](/CHANGELOG.md) under next version with high level changes in this PR.

# Usage
* You can potentially add a usage example below

```bash
++model.spin.generation_batch_size=XX
```
where XX is the batch size you want (e.g. 16)

# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? Make sure to also update the [NeMo Framework User Guide](https://docs.nvidia.com/nemo-framework/user-guide/latest/index.html) which contains the tutorials

# Checklist when contributing a new algorithm
- [ ] Does the trainer resume and restore model state all states?
- [ ] Does the trainer support all parallelism techniques(PP, TP, DP)?
- [ ] Does the trainer support `max_steps=-1` and `validation`?
- [ ] Does the trainer only call APIs defined in [alignable_interface.py](/nemo_aligner/models/alignable_interface.py)?
- [ ] Does the trainer have proper logging?

# Additional Information
* Related to # (issue)
