### PR TITLE
add moe support in reward model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## [Next Version]
 
 ### New features and optimizations
+- Add MoE Support for our reward models.
 
 ### Breaking changes
 

--- a/nemo_aligner/models/nlp/gpt/gpt_reward_model.py
+++ b/nemo_aligner/models/nlp/gpt/gpt_reward_model.py
@@ -162,6 +162,7 @@ class GPTRewardModel(GPTModel):
         share_embeddings_and_output_weights: bool = False,
         position_embedding_type: Literal["learned_absolute", "rope"] = "learned_absolute",
         rotary_percent: float = 1.0,
+        rotary_base: int = 10000,
         seq_len_interpolation_factor: Optional[float] = None,
         output_sequence: bool = False,
         use_avg_pool: bool = False,

--- a/nemo_aligner/models/nlp/gpt/gpt_reward_model.py
+++ b/nemo_aligner/models/nlp/gpt/gpt_reward_model.py
@@ -183,6 +183,7 @@ class GPTRewardModel(GPTModel):
             share_embeddings_and_output_weights=share_embeddings_and_output_weights,
             position_embedding_type=position_embedding_type,
             rotary_percent=rotary_percent,
+            rotary_base=rotary_base,
             seq_len_interpolation_factor=seq_len_interpolation_factor,
         )
 

--- a/nemo_aligner/models/nlp/gpt/megatron_gpt_reward_model.py
+++ b/nemo_aligner/models/nlp/gpt/megatron_gpt_reward_model.py
@@ -19,7 +19,6 @@ from typing import List, Union
 import torch
 from apex.transformer.pipeline_parallel.utils import _reconfigure_microbatch_calculator, get_num_microbatches
 from megatron.core import parallel_state
-from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
 from megatron.core.pipeline_parallel.schedules import get_forward_backward_func
 from omegaconf.dictconfig import DictConfig
 from pytorch_lightning.trainer.trainer import Trainer

--- a/nemo_aligner/models/nlp/gpt/megatron_gpt_reward_model.py
+++ b/nemo_aligner/models/nlp/gpt/megatron_gpt_reward_model.py
@@ -24,7 +24,7 @@ from megatron.core.pipeline_parallel.schedules import get_forward_backward_func
 from omegaconf.dictconfig import DictConfig
 from pytorch_lightning.trainer.trainer import Trainer
 
-from nemo.collections.nlp.models.language_modeling.megatron_gpt_model import MegatronGPTModel
+from nemo.collections.nlp.models.language_modeling.megatron_gpt_model import MegatronGPTModel, get_specs
 from nemo.collections.nlp.modules.common.megatron.utils import (
     average_losses_across_data_parallel_group,
     get_iterator_k_split,
@@ -90,7 +90,7 @@ class MegatronGPTRewardModel(MegatronGPTModel, SupervisedInterface, Inferrable):
 
         model = GPTRewardModel(
             config=self.transformer_config,
-            transformer_layer_spec=get_gpt_layer_with_transformer_engine_spec(),
+            transformer_layer_spec=get_specs(self.spec_name, self.transformer_config.num_moe_experts),
             vocab_size=self.cfg.get("override_vocab_size", self.padded_vocab_size),
             max_sequence_length=self.cfg.get("encoder_seq_length", 512),
             pre_process=pre_process,
@@ -100,6 +100,7 @@ class MegatronGPTRewardModel(MegatronGPTModel, SupervisedInterface, Inferrable):
             position_embedding_type=self.cfg.get("position_embedding_type", "learned_absolute"),
             rotary_percent=self.cfg.get("rotary_percentage", 1.0),
             seq_len_interpolation_factor=self.cfg.get("seq_len_interpolation_factor", None),
+            rotary_base=self.cfg.get("rotary_base", 10000),
             output_sequence=self.cfg.get("output_sequence", False),
             use_avg_pool=self.cfg.get("use_avg_pool", False),
             head_dtype=head_dtype,


### PR DESCRIPTION
# What does this PR do ?

Add moe support for reward model(this allows mixtral to be used). Note that by default the other models inherit MegatronGPTModel which has MoE support already. We need to add this because we use a modified GPTModel for the RM
