### PR TITLE
Allow computing logprobs of SFT model on input strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Fixed crash with float val check interval when checking progress in DPOTrainer
 - Fixed potential crash in SPIN when prompts are longer than encoder_seq_len - generation.max_length
 - Fixed crash when calling the `generate()` method of an SFT model with pipeline parallelism greater than two
+- Fixed crash when calling the `generate()` method of an SFT model with `compute_logprob=True` and string inputs
 
 ## [0.2.0] - 2024-02
 ### New features and optimizations


### PR DESCRIPTION
# What does this PR do ?

This fixes an issue where our new `generate()` method for SFT models didn't support string inputs at all. But when `compute_logprob=True`, we don't actually care about the padding & extra `predictions` key added by this method, so we can support string inputs easily by simply re-using the parent class' `generate()`.

This is useful e.g. for benchmarking purpose (this is how I tested it -- with the MMLU benchmark).