### PR TITLE
Fix implicit computation of `max_steps` when gbs < rollout size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Fixed potential crash in SPIN when prompts are longer than encoder_seq_len - generation.max_length
 - Fixed crash when calling the `generate()` method of an SFT model with pipeline parallelism greater than two
 - Fixed crash when calling the `generate()` method of an SFT model with `compute_logprob=True` and string inputs
+- Fixed the PPO learning rate schedule that could be very slightly incorrect with `global_batch_size` less than `num_rollout_samples`
 
 ## [0.2.0] - 2024-02
 ### New features and optimizations


### PR DESCRIPTION
This commit also ensures this code is compatible with the change in
        https://github.com/NVIDIA/NeMo/pull/8744
which requires using a NeMo sampler to compute `max_steps` correctly (it does not work with a basic PyTorch sampler).

Tested locally on my workstation.