### PR TITLE
Ea/multiple validation sets

### DIFF
--- a/nemo_aligner/algorithms/supervised.py
+++ b/nemo_aligner/algorithms/supervised.py
@@ -233,11 +233,10 @@ class SupervisedTrainer:
                 )
 
                 if run_val:
-                    val_loss, val_metrics = self.run_validation()
+                    _, val_metrics = self.run_validation()
                     # validation is done on the UPDATED weights
                     # so we use the incremented self.step
-                    self.logger.log_metrics(val_metrics, step=self.step, prefix="val/")
-                    val_metrics = {f"val_{k}": v for k, v in val_metrics.items()}
+                    self.logger.log_metrics(val_metrics, step=self.step, prefix="")
                     metrics.update(val_metrics)
 
                 global_pbar.set_postfix(metrics)

--- a/nemo_aligner/data/nlp/builders.py
+++ b/nemo_aligner/data/nlp/builders.py
@@ -121,7 +121,7 @@ def build_train_valid_test_datasets(
             k: build_dataset_generic(
                 cls=cls,
                 cfg=cfg,
-                data_prefix=data_prefix["validation"],
+                data_prefix=data_prefix[k],
                 data_impl=data_impl,
                 num_samples=int(train_valid_test_num_samples[0]),
                 seq_length=seq_length,

--- a/nemo_aligner/data/nlp/builders.py
+++ b/nemo_aligner/data/nlp/builders.py
@@ -51,7 +51,7 @@ from nemo_aligner.utils.utils import collate_with_batch_max_sequence_length
 
 
 def build_dataset_generic(cls, cfg, data_prefix, data_impl, num_samples, seq_length, seed, tokenizer, name):
-    def _build_dataset(current_data_prefix, current_num_samples):  # WARNING: current_num_samples not used
+    def _build_dataset(current_data_prefix, current_num_samples):
         if data_impl == "mmap":
             data_payload = get_indexed_dataset_(current_data_prefix, data_impl, cfg.data.get("skip_warmup", True))
         elif data_impl.startswith("json"):
@@ -66,7 +66,7 @@ def build_dataset_generic(cls, cfg, data_prefix, data_impl, num_samples, seq_len
         logging.info("     Total {} documents is : {} ".format(name, total_num_of_documents))
 
         drop_last = True
-        if name == "valid":  # WARNING: valid or validation?
+        if name == "valid":
             drop_last = cfg.data.get("validation_drop_last", True)
 
         dataset = cls(
@@ -85,7 +85,7 @@ def build_dataset_generic(cls, cfg, data_prefix, data_impl, num_samples, seq_len
     if len(data_prefix) == 1:
         return _build_dataset(data_prefix[0], num_samples)
     else:
-        output = get_datasets_weights_and_num_samples(data_prefix, num_samples)  # WARNING: num_samples has no effect
+        output = get_datasets_weights_and_num_samples(data_prefix, num_samples)
         data_prefixes, weights, datasets_num_samples = output
         datasets = []
         for i in range(len(data_prefixes)):
@@ -144,7 +144,7 @@ def build_train_valid_test_datasets(
         )
         return train_ds, dict_validation_ds, test_ds
 
-    else:  # TODO: when is data_prefix not a DictConfig?
+    else:
         # Single dataset.
         if len(data_prefix) == 1:
             return _build_train_valid_test_datasets(


### PR DESCRIPTION
# What does this PR do ?

Enable multiple validation datasets for reward model training. Metrics are computed individually on each dataset, and logged in separate wandb tabs.  

# Usage

You can add validation sets as new keys in `data_prefix`. These keys should start with "validation" to be taken into account as an optional validation set.

```bash
python examples/nlp/gpt/train_reward_model.py model.data.data_prefix={train: ["path_to_train_set"], validation: ["path_to_validation_set"], validation_optional: ["path_to_other_validation_set"], test: ["path_to_test_set"]}
```