### PR TITLE
Added support for float values for val_check_interval to SFT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - DPO: Enable LoRA on all model layers (In this case the actor will be reference model + LoRA weights, we can switch between actor/reference model by enabling/disabling LoRA)
 - PPO: Enable LoRA on all model layers (In this case the actor will be init policy + LoRA weights, we can switch between actor/init_policy model by enabling/disabling LoRA)
 - SteerLM 2.0: Add the SteerLM 2.0 model alignment method.
+- Added support for float values for `val_check_interval` for SFT
+- Added support for `limit_train_batches` as a float or int to DPO, SPIN, and SFT. This functionality mirrors the same parameter in PTL
 ### Breaking changes
 
 ### Bug Fixes
@@ -33,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Fixed crash when `model.micro_batch_size` > 1 in DPO
 - Fixed issue when `model.encoder_seq_length` is mismatched with `model.data.train_ds.max_seq_length` in SFT and SPIN.
 - Delete MegatronPretrainingRandomSampler from Aligner since it has been upstreamed into NeMo
+- Fixed SPIN not correctly using its `val_check_interval` parameter
 
 ## [0.3.0] - 2024-05
 

--- a/examples/nlp/gpt/conf/gpt_dpo.yaml
+++ b/examples/nlp/gpt/conf/gpt_dpo.yaml
@@ -13,6 +13,7 @@ trainer:
     max_steps: -1
     val_check_interval: 0.1
     save_interval: 100
+    limit_train_batches: 1.0
 
     # how many GBS we loop over
     limit_val_batches: 1.0

--- a/examples/nlp/gpt/conf/gpt_sft.yaml
+++ b/examples/nlp/gpt/conf/gpt_sft.yaml
@@ -12,6 +12,7 @@ trainer:
 
     val_check_interval: 100
     save_interval: ${.val_check_interval}
+    limit_train_batches: 1.0
 
     limit_val_batches: 1.0
     gradient_clip_val: 1.0

--- a/examples/nlp/gpt/conf/gpt_spin.yaml
+++ b/examples/nlp/gpt/conf/gpt_spin.yaml
@@ -14,7 +14,7 @@ trainer:
     max_steps: -1
     val_check_interval: 0.1
     save_interval: 100
-    limit_train_batches: null
+    limit_train_batches: 1.0
 
     # how many GBS we loop over
     limit_val_batches: 1.0

--- a/nemo_aligner/algorithms/dpo.py
+++ b/nemo_aligner/algorithms/dpo.py
@@ -100,11 +100,11 @@ class DPOTrainer:
         self.ckpt_callback = ckpt_callback
 
         # compute `max_steps`
-        self.num_steps_per_epoch = compute_num_steps_per_epoch(self.train_dataloader.batch_sampler)
+        self.num_steps_per_epoch = compute_num_steps_per_epoch(self.train_dataloader.batch_sampler, self.cfg.get("limit_train_batches", 1.0))
 
         self.limit_val_batches = compute_limit_batches(len(val_dataloader), self.cfg.limit_val_batches)
         self.val_check_interval = (
-            int(self.cfg.val_check_interval * len(self.train_dataloader))
+            int(self.cfg.val_check_interval * self.num_steps_per_epoch)
             if isinstance(self.cfg.val_check_interval, float)
             else self.cfg.val_check_interval
         )

--- a/nemo_aligner/algorithms/dpo.py
+++ b/nemo_aligner/algorithms/dpo.py
@@ -100,7 +100,9 @@ class DPOTrainer:
         self.ckpt_callback = ckpt_callback
 
         # compute `max_steps`
-        self.num_steps_per_epoch = compute_num_steps_per_epoch(self.train_dataloader.batch_sampler, self.cfg.get("limit_train_batches", 1.0))
+        self.num_steps_per_epoch = compute_num_steps_per_epoch(
+            self.train_dataloader.batch_sampler, self.cfg.get("limit_train_batches", 1.0)
+        )
 
         self.limit_val_batches = compute_limit_batches(len(val_dataloader), self.cfg.limit_val_batches)
         self.val_check_interval = (

--- a/nemo_aligner/algorithms/spin.py
+++ b/nemo_aligner/algorithms/spin.py
@@ -109,13 +109,11 @@ class SPINTrainer:
         self.ckpt_callback = ckpt_callback
 
         # compute `max_steps`
-        self.num_steps_per_epoch = compute_num_steps_per_epoch(self.train_dataloader.batch_sampler)
-        if (limit_train_batches := self.cfg.get("limit_train_batches")) is not None and limit_train_batches >= 0:
-            self.num_steps_per_epoch = min(self.num_steps_per_epoch, limit_train_batches)
+        self.num_steps_per_epoch = compute_num_steps_per_epoch(self.train_dataloader.batch_sampler, self.cfg.get("limit_train_batches", 1.0))
 
         self.limit_val_batches = compute_limit_batches(len(val_dataloader), self.cfg.limit_val_batches)
         self.val_check_interval = (
-            int(self.cfg.val_check_interval * self._train_dataloader_len)
+            int(self.cfg.val_check_interval * self.num_steps_per_epoch)
             if isinstance(self.cfg.val_check_interval, float)
             else self.cfg.val_check_interval
         )
@@ -330,7 +328,7 @@ class SPINTrainer:
                     run_val, save_model, is_train_end = check_progress(
                         self.step,
                         self.max_steps,
-                        self.cfg.val_check_interval,
+                        self.val_check_interval,
                         self.cfg.save_interval,
                         self.limit_val_batches,
                         run_time_exceeded=run_time_exceeded,

--- a/nemo_aligner/algorithms/spin.py
+++ b/nemo_aligner/algorithms/spin.py
@@ -109,7 +109,9 @@ class SPINTrainer:
         self.ckpt_callback = ckpt_callback
 
         # compute `max_steps`
-        self.num_steps_per_epoch = compute_num_steps_per_epoch(self.train_dataloader.batch_sampler, self.cfg.get("limit_train_batches", 1.0))
+        self.num_steps_per_epoch = compute_num_steps_per_epoch(
+            self.train_dataloader.batch_sampler, self.cfg.get("limit_train_batches", 1.0)
+        )
 
         self.limit_val_batches = compute_limit_batches(len(val_dataloader), self.cfg.limit_val_batches)
         self.val_check_interval = (

--- a/nemo_aligner/algorithms/supervised.py
+++ b/nemo_aligner/algorithms/supervised.py
@@ -67,9 +67,14 @@ class SupervisedTrainer:
         self.ckpt_callback = ckpt_callback
 
         # compute `max_steps`
-        self.num_steps_per_epoch = compute_num_steps_per_epoch(self.train_dataloader.batch_sampler)
+        self.num_steps_per_epoch = compute_num_steps_per_epoch(self.train_dataloader.batch_sampler, self.cfg.get("limit_train_batches", 1.0))
 
         self.limit_val_batches = compute_limit_batches(len(val_dataloader), self.cfg.limit_val_batches)
+        self.val_check_interval = (
+            int(self.cfg.val_check_interval * self.num_steps_per_epoch)
+            if isinstance(self.cfg.val_check_interval, float)
+            else self.cfg.val_check_interval
+        )
         self.set_max_steps()
 
         self.timer = SyncTimer(
@@ -210,7 +215,7 @@ class SupervisedTrainer:
                 run_val, save_model, is_train_end = check_progress(
                     self.step,
                     self.max_steps,
-                    self.cfg.val_check_interval,
+                    self.val_check_interval,
                     self.cfg.save_interval,
                     self.limit_val_batches,
                     run_time_exceeded=run_time_exceeded,

--- a/nemo_aligner/algorithms/supervised.py
+++ b/nemo_aligner/algorithms/supervised.py
@@ -67,7 +67,9 @@ class SupervisedTrainer:
         self.ckpt_callback = ckpt_callback
 
         # compute `max_steps`
-        self.num_steps_per_epoch = compute_num_steps_per_epoch(self.train_dataloader.batch_sampler, self.cfg.get("limit_train_batches", 1.0))
+        self.num_steps_per_epoch = compute_num_steps_per_epoch(
+            self.train_dataloader.batch_sampler, self.cfg.get("limit_train_batches", 1.0)
+        )
 
         self.limit_val_batches = compute_limit_batches(len(val_dataloader), self.cfg.limit_val_batches)
         self.val_check_interval = (

--- a/nemo_aligner/utils/trainer_utils.py
+++ b/nemo_aligner/utils/trainer_utils.py
@@ -26,12 +26,12 @@ def compute_num_steps_per_epoch(
 ):
     if not sampler.drop_last:
         raise NotImplementedError("`drop_last=False` is not currently supported")
-    
+
     num_steps_per_epoch = sampler.total_samples // sampler.global_batch_size
-    
+
     if limit_train_batches is None:
         limit_train_batches = 1.0
-    
+
     if limit_train_batches >= 0 and isinstance(limit_train_batches, float):
         return min(num_steps_per_epoch, int(sampler.total_samples * limit_train_batches) // sampler.global_batch_size)
     elif limit_train_batches >= 0 and isinstance(limit_train_batches, int):

--- a/nemo_aligner/utils/trainer_utils.py
+++ b/nemo_aligner/utils/trainer_utils.py
@@ -28,17 +28,7 @@ def compute_num_steps_per_epoch(
         raise NotImplementedError("`drop_last=False` is not currently supported")
 
     num_steps_per_epoch = sampler.total_samples // sampler.global_batch_size
-
-    if limit_train_batches is None:
-        limit_train_batches = 1.0
-
-    if limit_train_batches >= 0 and isinstance(limit_train_batches, float):
-        return min(num_steps_per_epoch, int(sampler.total_samples * limit_train_batches) // sampler.global_batch_size)
-    elif limit_train_batches >= 0 and isinstance(limit_train_batches, int):
-        return min(num_steps_per_epoch, limit_train_batches)
-    else:
-        return num_steps_per_epoch
-
+    return compute_limit_batches(num_steps_per_epoch, limit_train_batches)
 
 def compute_limit_batches(number_of_batches: int, limit_batches: Union[int, float, None]):
     if limit_batches is None:

--- a/nemo_aligner/utils/trainer_utils.py
+++ b/nemo_aligner/utils/trainer_utils.py
@@ -30,6 +30,7 @@ def compute_num_steps_per_epoch(
     num_steps_per_epoch = sampler.total_samples // sampler.global_batch_size
     return compute_limit_batches(num_steps_per_epoch, limit_train_batches)
 
+
 def compute_limit_batches(number_of_batches: int, limit_batches: Union[int, float, None]):
     if limit_batches is None:
         limit_batches = 1.0

--- a/nemo_aligner/utils/trainer_utils.py
+++ b/nemo_aligner/utils/trainer_utils.py
@@ -21,12 +21,23 @@ from nemo.collections.nlp.data.language_modeling.megatron.megatron_batch_sampler
 
 
 def compute_num_steps_per_epoch(
-    sampler: Union[MegatronPretrainingRandomSampler, MegatronPretrainingRandomBatchSampler]
+    sampler: Union[MegatronPretrainingRandomSampler, MegatronPretrainingRandomBatchSampler],
+    limit_train_batches: Union[int, float] = 1.0,
 ):
     if not sampler.drop_last:
         raise NotImplementedError("`drop_last=False` is not currently supported")
-
-    return sampler.total_samples // sampler.global_batch_size
+    
+    num_steps_per_epoch = sampler.total_samples // sampler.global_batch_size
+    
+    if limit_train_batches is None:
+        limit_train_batches = 1.0
+    
+    if limit_train_batches >= 0 and isinstance(limit_train_batches, float):
+        return min(num_steps_per_epoch, int(sampler.total_samples * limit_train_batches) // sampler.global_batch_size)
+    elif limit_train_batches >= 0 and isinstance(limit_train_batches, int):
+        return min(num_steps_per_epoch, limit_train_batches)
+    else:
+        return num_steps_per_epoch
 
 
 def compute_limit_batches(number_of_batches: int, limit_batches: Union[int, float, None]):

--- a/nemo_aligner/utils/trainer_utils.py
+++ b/nemo_aligner/utils/trainer_utils.py
@@ -28,10 +28,10 @@ def compute_num_steps_per_epoch(
         raise NotImplementedError("`drop_last=False` is not currently supported")
 
     num_steps_per_epoch = sampler.total_samples // sampler.global_batch_size
-    
+
     if limit_train_batches is None or limit_train_batches > 1.0:
         limit_train_batches = 1.0
-    
+
     if limit_train_batches >= 0:
         return compute_limit_batches(num_steps_per_epoch, limit_train_batches)
     else:

--- a/nemo_aligner/utils/trainer_utils.py
+++ b/nemo_aligner/utils/trainer_utils.py
@@ -28,7 +28,14 @@ def compute_num_steps_per_epoch(
         raise NotImplementedError("`drop_last=False` is not currently supported")
 
     num_steps_per_epoch = sampler.total_samples // sampler.global_batch_size
-    return compute_limit_batches(num_steps_per_epoch, limit_train_batches)
+    
+    if limit_train_batches is None or limit_train_batches > 1.0:
+        limit_train_batches = 1.0
+    
+    if limit_train_batches >= 0:
+        return compute_limit_batches(num_steps_per_epoch, limit_train_batches)
+    else:
+        return num_steps_per_epoch
 
 
 def compute_limit_batches(number_of_batches: int, limit_batches: Union[int, float, None]):


### PR DESCRIPTION
# What does this PR do ?

Adds support for float values for `val_check_interval` for SFT. It also adds support for floats/ints for `limit_train_batches` to SFT and DPO, as per the usage in [PTL](https://lightning.ai/docs/pytorch/stable/common/trainer.html#limit-train-batches)

This was requested by @Kipok 

# Changelog 
- Please update the [CHANGELOG.md](/CHANGELOG.md) under next version with high level changes in this PR.

# Usage
* You can potentially add a usage example below

```yaml
val_check_interval = 0.25   # means you will run validation 4 times per epoch
val_check_interval = 100    # means you will run validation every 100 steps of training
limit_train_batches = 0.5   # you will only use 50% of your training data per epoch
limit_train_batches = 100  # you will only consume 100 steps of your train dataloader per epoch
```

All possibilities can be used for SFT, DPO, and SPIN


# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? Make sure to also update the [NeMo Framework User Guide](https://docs.nvidia.com/nemo-framework/user-guide/latest/index.html) which contains the tutorials

# Checklist when contributing a new algorithm
- [ ] Does the trainer resume and restore model state all states?
- [ ] Does the trainer support all parallelism techniques(PP, TP, DP)?
- [ ] Does the trainer support `max_steps=-1` and `validation`?
- [ ] Does the trainer only call APIs defined in [alignable_interface.py](/nemo_aligner/models/alignable_interface.py)?
- [ ] Does the trainer have proper logging?

# Additional Information
* Related to # (issue)
