### PR TITLE
SPIN: Added logging for avg generation length and generated responses as wandb table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## [0.3.1] - 2024-05
 - SPIN: added `rollout_micro_batch_size` parameter which allows users to set the batch size for doing generation during SPIN training.
         previously the generation batch size was automatically set to the data parallel size (DP) of the model
+- SPIN: added wandb logging of average generation length and a small sample of generated responses (in plaintext) along with corresponding prompts
 
 ### New features and optimizations
 - Add MoE Support for our reward models.

--- a/nemo_aligner/algorithms/spin.py
+++ b/nemo_aligner/algorithms/spin.py
@@ -14,6 +14,7 @@
 
 from collections import defaultdict
 from statistics import mean
+import pandas as pd
 
 import torch
 from megatron.core import parallel_state
@@ -134,6 +135,9 @@ class SPINTrainer:
         ), f"rollout_micro_batch_size [{self.model.cfg.spin.rollout_micro_batch_size}] must be a multiple of GBS [{self.model.cfg.global_batch_size}] // DP [{parallel_state.get_data_parallel_world_size()}]"
         self.rollout_micro_batch_size = self.model.cfg.spin.rollout_micro_batch_size
         assert self.rollout_micro_batch_size > 0, "`rollout_micro_batch_size` must be > 0"
+        
+        # for wandb table
+        self.train_df = pd.DataFrame(columns=["step", "prompt", "response"])
 
     def validation_step(self, global_batch):
         # these things should go into a GPTModel wrapper
@@ -198,6 +202,23 @@ class SPINTrainer:
         if grad_norm is not None:
             trainer_metrics["grad_norm"] = grad_norm
         trainer_metrics.update({"lr": lr, "loss": loss_mean})
+        
+        num_samples = 0
+        gen_lengths = 0
+        num_samples += global_batch['actual'].shape[0]
+        gen_lengths += global_batch['generated_lengths'].sum()
+        tensor_to_accumulate = torch.tensor(
+            [gen_lengths, num_samples],
+            dtype=torch.float32,
+            device=torch.cuda.current_device(),
+        )
+        torch.distributed.all_reduce(tensor_to_accumulate, group=parallel_state.get_data_parallel_group())
+
+        (
+            global_response_lengths,
+            global_num_samples,
+        ) = tensor_to_accumulate.tolist()
+        metrics['avg_generated_lengths'] = (global_response_lengths / global_num_samples)
 
         return loss_mean, {**metrics, **trainer_metrics}
 
@@ -343,6 +364,15 @@ class SPINTrainer:
                         self.logger.log_metrics(val_metrics, step=self.step, prefix="val/")
                         val_metrics = {f"val_{k}": v for k, v in val_metrics.items()}
                         metrics.update(val_metrics)
+                        
+                        # we update the pandas table here only during validation to avoid blowing up wandb storage space
+                        # we update only for rank 0 although this is redudant because .log_table() only works on rank 0
+                        if torch.distributed.get_rank() == 0 and parallel_state.get_data_parallel_rank() == 0:
+                            self.train_df.loc[len(self.train_df)] = [self.step - 1, self.model.tokenizer.ids_to_text(global_batch["prompts_only"][0].tolist()), self.model.tokenizer.ids_to_text(global_batch["generated"][0][len(global_batch["prompts_only"][0]):(len(global_batch["prompts_only"][0]) + global_batch["generated_lengths"][0].item())].tolist())]
+                            self.logger.log_table(
+                                key="table/train_generations", dataframe=self.train_df, step=self.step - 1,
+                            )
+                        torch.distributed.barrier()
 
                     global_pbar.set_postfix(metrics)
 
@@ -478,6 +508,9 @@ class SPINTrainer:
                     new_batch["position_ids"] = position_ids
                     new_batch["actual_mask"] = act_mask
                     new_batch["generated_mask"] = gen_mask
+                    new_batch["prompts_only"] = batch["prompts_only"]
+                    new_batch["generated_lengths"] = gen_lengths - batch["prompt_lengths"]
+                    assert (gen_lengths - batch["prompt_lengths"] >= 0).all(), "negative generated length encountered"
 
                     logprobs = self.model.get_ref_policy_logprobs(new_batch).cpu()
                     act_logps, gen_logps = torch.split(logprobs, len(logprobs) // 2, dim=0)


### PR DESCRIPTION
# What does this PR do ?

Adds wandb logging of avg generation length for SPIN as well as a table showing sample generated responses for their corresponding prompts.

# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? Make sure to also update the [NeMo Framework User Guide](https://docs.nvidia.com/nemo-framework/user-guide/latest/index.html) which contains the tutorials

# Checklist when contributing a new algorithm
- [ ] Does the trainer resume and restore model state all states?
- [ ] Does the trainer support all parallelism techniques(PP, TP, DP)?
- [ ] Does the trainer support `max_steps=-1` and `validation`?
- [ ] Does the trainer only call APIs defined in [alignable_interface.py](/nemo_aligner/models/alignable_interface.py)?
- [ ] Does the trainer have proper logging?

# Additional Information
* Related to # (issue)
