### PR TITLE
Add feat to allow GPTSFTModel.generate from str inputs

### DIFF
--- a/nemo_aligner/models/nlp/gpt/gpt_sft_model.py
+++ b/nemo_aligner/models/nlp/gpt/gpt_sft_model.py
@@ -33,6 +33,7 @@ from nemo.collections.nlp.modules.common.transformer.text_generation import Leng
 from nemo.collections.nlp.parts.mixins.nlp_adapter_mixins import NLPAdapterModelMixin
 from nemo.collections.nlp.parts.utils_funcs import get_last_rank
 from nemo_aligner.models.alignable_interface import SupervisedInterface
+from nemo_aligner.utils.text_generation_utils import tokenize_batch
 from nemo_aligner.utils.train_utils import (
     finish_validation_step,
     grad_reductions,
@@ -164,12 +165,17 @@ class GPTSFTModel(NLPAdapterModelMixin, MegatronGPTModel, SupervisedInterface):
                 inputs=inputs, length_params=length_params, sampling_params=sampling_params, strategy=strategy
             )
 
-        if isinstance(inputs, (list, tuple)) and isinstance(inputs[0], str):
-            raise NotImplementedError(
-                "`GPTSFTModel.generate()` does not currently support string inputs, please tokenize prompts first"
-            )
+        if not isinstance(inputs, (list, tuple)):
+            raise NotImplementedError(f"Expected type(inputs)=(list or tuple) but got {type(inputs)=}")
 
-        prompt_tokens, prompt_lengths = inputs
+        if isinstance(inputs[0], str):
+            # add_EOS=False since it is absent from nemo.collections.nlp.modules.common.text_generation_utils.megatron_gpt_generate
+            prompt_tokens, prompt_lengths, _ = tokenize_batch(
+                sentences=inputs, tokenizer=self.tokenizer, max_len=self.cfg.encoder_seq_length, add_BOS=sampling_params['add_BOS'], add_EOS=False,
+            )
+        else:
+            prompt_tokens, prompt_lengths = inputs
+
         max_prompt_length = prompt_lengths.max().item()
         max_response_length = length_params["max_length"]
         max_length = max_prompt_length + max_response_length

--- a/nemo_aligner/models/nlp/gpt/gpt_sft_model.py
+++ b/nemo_aligner/models/nlp/gpt/gpt_sft_model.py
@@ -171,7 +171,11 @@ class GPTSFTModel(NLPAdapterModelMixin, MegatronGPTModel, SupervisedInterface):
         if isinstance(inputs[0], str):
             # add_EOS=False since it is absent from nemo.collections.nlp.modules.common.text_generation_utils.megatron_gpt_generate
             prompt_tokens, prompt_lengths, _ = tokenize_batch(
-                sentences=inputs, tokenizer=self.tokenizer, max_len=self.cfg.encoder_seq_length, add_BOS=sampling_params['add_BOS'], add_EOS=False,
+                sentences=inputs,
+                tokenizer=self.tokenizer,
+                max_len=self.cfg.encoder_seq_length,
+                add_BOS=sampling_params["add_BOS"],
+                add_EOS=False,
             )
         else:
             prompt_tokens, prompt_lengths = inputs


### PR DESCRIPTION
The type support for inputs now matches MegatronGPTModel which was important to use megatron_gpt_eval.py

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog 
- Please update the [CHANGELOG.md](/CHANGELOG.md) under next version with high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? Make sure to also update the [NeMo Framework User Guide](https://docs.nvidia.com/nemo-framework/user-guide/latest/index.html) which contains the tutorials

# Checklist when contributing a new algorithm
- [ ] Does the trainer resume and restore model state all states?
- [ ] Does the trainer support all parallelism techniques(PP, TP, DP)?
- [ ] Does the trainer support `max_steps=-1` and `validation`?
- [ ] Does the trainer only call APIs defined in [alignable_interface.py](/nemo_aligner/models/alignable_interface.py)?
- [ ] Does the trainer have proper logging?

# Additional Information
* Related to # (issue)
