### PR TITLE
Avoids crash in PPOTrainer if using adafactor w/o learning rate

### DIFF
--- a/nemo_aligner/algorithms/ppo.py
+++ b/nemo_aligner/algorithms/ppo.py
@@ -445,8 +445,11 @@ class PPOTrainer:
 
             if grad_norm is not None:
                 metrics["grad_norm"] = grad_norm
+            if lr is not None:
+                # Some optimizers like adafactor do not require a LR in their initializer
+                metrics["lr"] = lr
 
-            metrics.update({"lr": lr, "loss": loss_mean, "optim_step": self.ppo_optimization_step})
+            metrics.update({"loss": loss_mean, "optim_step": self.ppo_optimization_step})
             metrics["train_step_time"] = self.timer.stop_and_get_time("train_step_time")
 
             self.logger.log_metrics(


### PR DESCRIPTION
# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog 
- Please update the [CHANGELOG.md](/CHANGELOG.md) under next version with high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? Make sure to also update the [NeMo Framework User Guide](https://docs.nvidia.com/nemo-framework/user-guide/latest/index.html) which contains the tutorials

# Checklist when contributing a new algorithm
- [ ] Does the trainer resume and restore model state all states?
- [ ] Does the trainer support all parallelism techniques(PP, TP, DP)?
- [ ] Does the trainer support `max_steps=-1` and `validation`?
- [ ] Does the trainer only call APIs defined in [alignable_interface.py](/nemo_aligner/models/alignable_interface.py)?
- [ ] Does the trainer have proper logging?

# Additional Information
* Related to # (issue)
