### PR TITLE
Enforce that mcore is >=0.8 for Aligner 0.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 jsonlines
 nemo_toolkit[nlp]
 nvidia-pytriton
+megatron_core>=0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jsonlines
+megatron_core>=0.8
 nemo_toolkit[nlp]
 nvidia-pytriton
-megatron_core>=0.8


### PR DESCRIPTION
This will fail until mcore pushes their wheel, but within the dockerfile that checks out ToT megatron, this should work

Depends on #252 