### PR TITLE
Fix num_micro_batches when using forward_mbs

### DIFF
--- a/nemo_aligner/models/nlp/gpt/megatron_gpt_dpo_model.py
+++ b/nemo_aligner/models/nlp/gpt/megatron_gpt_dpo_model.py
@@ -19,6 +19,7 @@ import torch
 from megatron.core import parallel_state
 from megatron.core.num_microbatches_calculator import get_num_microbatches
 from megatron.core.pipeline_parallel.schedules import get_forward_backward_func
+from megatron.core.utils import divide
 from omegaconf.dictconfig import DictConfig
 from pytorch_lightning.trainer.trainer import Trainer
 
@@ -407,10 +408,7 @@ class MegatronGPTDPOModel(NLPAdapterModelMixin, MegatronGPTModel, SupervisedInte
         seq_length = batch["chosen"].shape[1]
         batch_size = batch["chosen"].shape[0]
 
-        assert (
-            batch_size * 2
-        ) % self.cfg.dpo.log_prob_forward_micro_batch_size == 0, f"batch_size ({batch_size}) * 2 is not divisble by log_prob_forward_micro_batch_size ({self.cfg.dpo.log_prob_forward_micro_batch_size})."
-        num_microbatches = int(batch_size * 2 // self.cfg.dpo.log_prob_forward_micro_batch_size)
+        num_microbatches = divide(batch_size * 2, self.cfg.dpo.log_prob_forward_micro_batch_size)
         data_iter = get_iterator_k_split(batch, num_microbatches)
         set_sync_funcs(self, forward_only=True)
 

--- a/nemo_aligner/models/nlp/gpt/megatron_gpt_dpo_model.py
+++ b/nemo_aligner/models/nlp/gpt/megatron_gpt_dpo_model.py
@@ -407,7 +407,9 @@ class MegatronGPTDPOModel(NLPAdapterModelMixin, MegatronGPTModel, SupervisedInte
         seq_length = batch["chosen"].shape[1]
         batch_size = batch["chosen"].shape[0]
 
-        assert (batch_size * 2) % self.cfg.dpo.log_prob_forward_micro_batch_size == 0, f"batch_size ({batch_size}) * 2 is not divisble by log_prob_forward_micro_batch_size ({self.cfg.dpo.log_prob_forward_micro_batch_size})."
+        assert (
+            batch_size * 2
+        ) % self.cfg.dpo.log_prob_forward_micro_batch_size == 0, f"batch_size ({batch_size}) * 2 is not divisble by log_prob_forward_micro_batch_size ({self.cfg.dpo.log_prob_forward_micro_batch_size})."
         num_microbatches = int(batch_size * 2 // self.cfg.dpo.log_prob_forward_micro_batch_size)
         data_iter = get_iterator_k_split(batch, num_microbatches)
         set_sync_funcs(self, forward_only=True)

--- a/nemo_aligner/models/nlp/gpt/megatron_gpt_dpo_model.py
+++ b/nemo_aligner/models/nlp/gpt/megatron_gpt_dpo_model.py
@@ -405,8 +405,11 @@ class MegatronGPTDPOModel(NLPAdapterModelMixin, MegatronGPTModel, SupervisedInte
     @torch.no_grad()
     def get_logprob_batch(self, batch):
         seq_length = batch["chosen"].shape[1]
+        batch_size = batch["chosen"].shape[0]
 
-        data_iter = get_iterator_k_split(batch, get_num_microbatches())
+        assert (batch_size * 2) % self.cfg.dpo.log_prob_forward_micro_batch_size == 0, f"batch_size ({batch_size}) * 2 is not divisble by log_prob_forward_micro_batch_size ({self.cfg.dpo.log_prob_forward_micro_batch_size})."
+        num_microbatches = int(batch_size * 2 // self.cfg.dpo.log_prob_forward_micro_batch_size)
+        data_iter = get_iterator_k_split(batch, num_microbatches)
         set_sync_funcs(self, forward_only=True)
 
         fwd_bwd_function = get_forward_backward_func()
@@ -415,7 +418,7 @@ class MegatronGPTDPOModel(NLPAdapterModelMixin, MegatronGPTModel, SupervisedInte
             forward_step_func=self.get_forward_output_and_loss_func(logprobs_only=True),
             data_iterator=data_iter,
             model=self.model,
-            num_microbatches=get_num_microbatches(),
+            num_microbatches=num_microbatches,
             forward_only=True,
             seq_length=seq_length,
             micro_batch_size=self.cfg.dpo.log_prob_forward_micro_batch_size,


### PR DESCRIPTION
# What does this PR do ?

Fix the `num_microbatches` in `forward_backward_func` when using customized `log_prob_forward_micro_batch_size`.

* When using the default `log_prob_forward_mbs = 2 * micro_batch_size`, this does not affect `num_microbatches`.
* When using a customized `log_prob_forward_mbs`, the `num_microbatches` should be changed accordingly.

# Changelog 
- Please update the [CHANGELOG.md](/CHANGELOG.md) under next version with high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? Make sure to also update the [NeMo Framework User Guide](https://docs.nvidia.com/nemo-framework/user-guide/latest/index.html) which contains the tutorials

# Checklist when contributing a new algorithm
- [ ] Does the trainer resume and restore model state all states?
- [ ] Does the trainer support all parallelism techniques(PP, TP, DP)?
- [ ] Does the trainer support `max_steps=-1` and `validation`?
- [ ] Does the trainer only call APIs defined in [alignable_interface.py](/nemo_aligner/models/alignable_interface.py)?
- [ ] Does the trainer have proper logging?

# Additional Information
* Related to # (issue)
