### PR TITLE
feat: update dockerfile to allow incremental builds and change TRTLLM error to point to dockerfile

### DIFF
--- a/nemo_aligner/models/nlp/gpt/megatron_gpt_ppo_actor.py
+++ b/nemo_aligner/models/nlp/gpt/megatron_gpt_ppo_actor.py
@@ -50,7 +50,7 @@ from nemo_aligner.utils.train_utils import (
     set_sync_funcs,
     set_train,
 )
-from nemo_aligner.utils.trt_llm import HAVE_TRTLLM, GPTGenerateTRTLLM
+from nemo_aligner.utils.trt_llm import GPTGenerateTRTLLM
 from nemo_aligner.utils.utils import (
     adapter_control,
     clear_memory,
@@ -81,7 +81,6 @@ class MegatronGPTActorModel(NLPAdapterModelMixin, MegatronGPTModel, AlignableGen
 
         self.use_trtllm_generation = "trt_llm" in self.cfg.ppo and self.cfg.ppo.trt_llm.enable
         if self.use_trtllm_generation:
-            assert HAVE_TRTLLM, "TRTLLM generation was enabled but TRTLLM was not able to be imported"
             self.trtllm_generate = GPTGenerateTRTLLM(
                 model_cfg=self.cfg,
                 max_generation_length=self.cfg.ppo.length_params.get("max_length", 1024),

--- a/nemo_aligner/utils/trt_llm.py
+++ b/nemo_aligner/utils/trt_llm.py
@@ -54,7 +54,9 @@ class GPTGenerateTRTLLM:
         trt_model_dir="/tmp/trt_llm_model",
     ):
         if not HAVE_TRTLLM:
-            raise RuntimeError("You are trying to use NeMo-Aligner's TensorRT-LLM acceleration for LLM generation. Please build the dockerfile to enable this feature: https://github.com/NVIDIA/NeMo-Aligner/blob/main/Dockerfile")
+            raise RuntimeError(
+                "You are trying to use NeMo-Aligner's TensorRT-LLM acceleration for LLM generation. Please build the dockerfile to enable this feature: https://github.com/NVIDIA/NeMo-Aligner/blob/main/Dockerfile"
+            )
 
         # If this assert turns out to be a blocker with some tokenizers, potential workarounds could be to:
         #   - add a config option to allow specifying which token we pass as `end_id` to TRT-LLM (should

--- a/nemo_aligner/utils/trt_llm.py
+++ b/nemo_aligner/utils/trt_llm.py
@@ -53,6 +53,9 @@ class GPTGenerateTRTLLM:
         reshard_model=False,
         trt_model_dir="/tmp/trt_llm_model",
     ):
+        if not HAVE_TRTLLM:
+            raise RuntimeError("You are trying to use NeMo-Aligner's TensorRT-LLM acceleration for LLM generation. Please build the dockerfile to enable this feature: https://github.com/NVIDIA/NeMo-Aligner/blob/main/Dockerfile")
+
         # If this assert turns out to be a blocker with some tokenizers, potential workarounds could be to:
         #   - add a config option to allow specifying which token we pass as `end_id` to TRT-LLM (should
         #     be a token that the model is guaranteed to never generate)


### PR DESCRIPTION
# What does this PR do ?

This PR contains two changes:
1. Change to the dockerfile to allow two types of builds
```sh
# Original build
docker buildx build -t aligner:latest .

# An incremental build where only nemo-aligner gets bumped changes

docker buildx build --target=aligner-bump \
  --build-arg=BASE_IMAGE=nvcr.io/nvidia/nemo:24.07 \
  --build-arg=ALIGNER_COMMIT=dev \
  -t aligner:latest .
```

2. Moves the error message when either (a) TRTLLM isn't installed (b) doesn't have v10 refit functionality into GenerateGPTLLM and have the message point to this new dockerfile

# Changelog 
- Please update the [CHANGELOG.md](/CHANGELOG.md) under next version with high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? Make sure to also update the [NeMo Framework User Guide](https://docs.nvidia.com/nemo-framework/user-guide/latest/index.html) which contains the tutorials

# Checklist when contributing a new algorithm
- [ ] Does the trainer resume and restore model state all states?
- [ ] Does the trainer support all parallelism techniques(PP, TP, DP)?
- [ ] Does the trainer support `max_steps=-1` and `validation`?
- [ ] Does the trainer only call APIs defined in [alignable_interface.py](/nemo_aligner/models/alignable_interface.py)?
- [ ] Does the trainer have proper logging?

# Additional Information
* Related to # (issue)
