### PR TITLE
ci: Allow running on main

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   build:
     runs-on: self-hosted-builder
-    if: ${{ github.event.label.name == 'Run CICD' }}
+    if: ${{ github.event.label.name == 'Run CICD' || github.ref == 'refs/heads/main' }}
     steps:
       - name: Clean runner cache
         run: | 


### PR DESCRIPTION
# What does this PR do ?

Current rules disallow running on main, as the label `Run CICD` aint there

# Changelog 
- Please update the [CHANGELOG.md](/CHANGELOG.md) under next version with high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? Make sure to also update the [NeMo Framework User Guide](https://docs.nvidia.com/nemo-framework/user-guide/latest/index.html) which contains the tutorials

# Checklist when contributing a new algorithm
- [ ] Does the trainer resume and restore model state all states?
- [ ] Does the trainer support all parallelism techniques(PP, TP, DP)?
- [ ] Does the trainer support `max_steps=-1` and `validation`?
- [ ] Does the trainer only call APIs defined in [alignable_interface.py](/nemo_aligner/models/alignable_interface.py)?
- [ ] Does the trainer have proper logging?

# Additional Information
* Related to # (issue)
