### PR TITLE
fix: Dockerfile now correctly updates aligner in incremental aligner-bump target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 # To update NeMo-Aligner from a pre-built NeMo-Framework container:
 #
-#   docker buildx build --target=aligner-bump -t aligner:latest .
+#   docker buildx build --target=aligner-bump --build-arg=BASE_IMAGE=nvcr.io/nvidia/nemo:24.07 -t aligner:latest .
 #
 
 # Number of parallel threads for compute heavy build jobs
@@ -27,11 +27,14 @@ WORKDIR /opt
 RUN <<"EOF" bash -exu
 if [[ ! -d NeMo-Aligner ]]; then
     git clone https://github.com/NVIDIA/NeMo-Aligner.git
-    cd NeMo-Aligner
-    git checkout $ALIGNER_COMMIT
-else
-    cd NeMo-Aligner
 fi
+cd NeMo-Aligner
+git fetch -a
+# -f since git status may not be clean
+git checkout -f $ALIGNER_COMMIT
+# case 1: ALIGNER_COMMIT is a local branch so we have to apply remote changes to it
+# case 2: ALIGNER_COMMIT is a commit, so git-pull is expected to fail
+git pull --rebase || true
 
 pip install --no-deps -e .
 EOF


### PR DESCRIPTION

# What does this PR do ?

Fixes the incremental build which wasn't bumping aligner

```sh
docker buildx build --build-arg=BASE_IMAGE=nvcr.io/nvidia/nemo:24.07 --target=aligner-bump -t aligner:latest https://github.com/NVIDIA/NeMo-Aligner.git#tk/0.5/dockerfile-fix
```
# Changelog 
- Please update the [CHANGELOG.md](/CHANGELOG.md) under next version with high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? Make sure to also update the [NeMo Framework User Guide](https://docs.nvidia.com/nemo-framework/user-guide/latest/index.html) which contains the tutorials

# Checklist when contributing a new algorithm
- [ ] Does the trainer resume and restore model state all states?
- [ ] Does the trainer support all parallelism techniques(PP, TP, DP)?
- [ ] Does the trainer support `max_steps=-1` and `validation`?
- [ ] Does the trainer only call APIs defined in [alignable_interface.py](/nemo_aligner/models/alignable_interface.py)?
- [ ] Does the trainer have proper logging?

# Additional Information
* Related to # (issue)
