### PR TITLE
Cherry pick `fix: serve_reward_model.py no longer errors if pretrained GBS indivisible by parallel state (333)` into `r0.5.0`

### DIFF
--- a/examples/nlp/gpt/conf/inference_rm.yaml
+++ b/examples/nlp/gpt/conf/inference_rm.yaml
@@ -49,3 +49,7 @@ model:
   regression:
     merge_attributes: False # whether to merge attribute values into a scalar
     attribute_weights: null # apply these weights to each attributes when merging them into a scalar
+
+  # NOTE: The user does not need to change the global batch size below
+  # GBS is overridden to 0 to disable checks for compatibility with the megatron-core parallel state
+  global_batch_size: 0


### PR DESCRIPTION
[🤖]: Hi @terrykong 👋,<br><br>we've cherry picked #333 into `r0.5.0` for you! 🚀<br><br>Please review and approve this cherry pick by your convenience\!