### PR TITLE
Fixed string literal error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Bug Fixes
 
+- Changed class comment under `RegressionRewardModelDataset` such that the warning comment: "WARNING: It's recommended to preprocess..." is now "WARNING: It is recommended to preprocess". Allows for wider compatiblity by fixing a syntax error due ot an unterminated string literal bug caused by the ' character when running code.
+
 ## NVIDIA NeMo-Aligner 0.5.0
 
 ### New Features and Optimizations

--- a/nemo_aligner/data/nlp/datasets.py
+++ b/nemo_aligner/data/nlp/datasets.py
@@ -454,7 +454,7 @@ class RegressionRewardModelDataset(RewardModelDataset):
         we should set missing attributes to model.regression.loss_mask_val(according to training_rm.yaml)
         in the dataset files so that their losses are masked. At least one attribute should be present for each sample.
 
-        WARNING: It's recommended to preprocess your data in advance to ensure all samples are within self.seq_length.
+        WARNING: It is recommended to preprocess your data in advance to ensure all samples are within self.seq_length.
                  Otherwise if all samples in a batch are longer than self.seq_length, you may get NaN loss.
     """
 


### PR DESCRIPTION
# What does this PR do ?

Fixed the following string literal bug:

```
Traceback (most recent call last):
  File "/eph/nvme0/azureml/cr/j/5f8208feac9e43b3b90284ba713c821b/exe/wd/train_reward_model.py", line 22, in <module>
    from nemo_aligner.data.nlp.builders import (
  File "/opt/NeMo-Aligner/nemo_aligner/data/nlp/builders.py", line 45, in <module>
    from nemo_aligner.data.nlp.datasets import (
  File "/opt/NeMo-Aligner/nemo_aligner/data/nlp/datasets.py", line 346
    WARNING: It's recommended to preprocess your data in advance to ensure all samples are within self.seq_length.
               ^
SyntaxError: unterminated string literal (detected at line 346)
```

By changing It's to It is. This fix offers a wider range of compatibility without really modifying any of the logic.

# Changelog 
- Please update the [CHANGELOG.md](/CHANGELOG.md) under next version with high level changes in this PR.

Changelog updated

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? **No necessary tests.**
- [x] Did you add or update any necessary documentation? Make sure to also update the [NeMo Framework User Guide](https://docs.nvidia.com/nemo-framework/user-guide/latest/index.html) which contains the tutorials. **No documentation update necessary.**
