### PR TITLE
docs: Added note about GBS and jsonl samples to DPO tutorial

### DIFF
--- a/docs/user-guide/dpo.rst
+++ b/docs/user-guide/dpo.rst
@@ -90,6 +90,8 @@ However, please be aware that most Megatron GPT models adhere to a strict format
 
 Always follow the prompt-response template format used during your SFT training for DPO, as failure to do so will produce a model which outputs garbage text. You should create one jsonl file in the format above for your training data and one jsonl for your validation data.
 
+Please note: your jsonl file needs to have at least as many samples as the Global Batch Size you plan to use during training. So if your GBS=64, ensure that both your training and validation files have at least 64 samples. Using a file which has fewer samples than GBS will result in a crash.
+
 Once your data is processed into the correct format, you are ready to begin DPO training. You must start with a pretrained or SFT trained model. For this section, we will use the SFT model trained in the previous step to train the DPO model.
 For the purposes of the following sections, we assume that your training jsonl file is located in ``/path/to/train_dpo_format.jsonl`` and your validation jsonl file is located in ``/path/to/valid_dpo_format.jsonl``.
 

--- a/docs/user-guide/dpo.rst
+++ b/docs/user-guide/dpo.rst
@@ -90,7 +90,7 @@ However, please be aware that most Megatron GPT models adhere to a strict format
 
 Always follow the prompt-response template format used during your SFT training for DPO, as failure to do so will produce a model which outputs garbage text. You should create one jsonl file in the format above for your training data and one jsonl for your validation data.
 
-Please note: your jsonl file needs to have at least as many samples as the Global Batch Size you plan to use during training. So if your GBS=64, ensure that both your training and validation files have at least 64 samples. Using a file which has fewer samples than GBS will result in a crash.
+Your JSONL file must contain at least as many samples as the Global Batch Size (GBS) you plan to use during training. For example, if GBS = 64, ensure that both your training and validation files include at least 64 samples. Using a file with fewer samples than the GBS will result in a crash.
 
 Once your data is processed into the correct format, you are ready to begin DPO training. You must start with a pretrained or SFT trained model. For this section, we will use the SFT model trained in the previous step to train the DPO model.
 For the purposes of the following sections, we assume that your training jsonl file is located in ``/path/to/train_dpo_format.jsonl`` and your validation jsonl file is located in ``/path/to/valid_dpo_format.jsonl``.


### PR DESCRIPTION
# What does this PR do ?

Adds a note to the DPO tutorial that train/valid jsonl files must have at least GBS number of samples each.

# Changelog 
- Please update the [CHANGELOG.md](/CHANGELOG.md) under next version with high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? Make sure to also update the [NeMo Framework User Guide](https://docs.nvidia.com/nemo-framework/user-guide/latest/index.html) which contains the tutorials

# Checklist when contributing a new algorithm
- [ ] Does the trainer resume and restore model state all states?
- [ ] Does the trainer support all parallelism techniques(PP, TP, DP)?
- [ ] Does the trainer support `max_steps=-1` and `validation`?
- [ ] Does the trainer only call APIs defined in [alignable_interface.py](/nemo_aligner/models/alignable_interface.py)?
- [ ] Does the trainer have proper logging?

# Additional Information
* Related to # (issue)
