### PR TITLE
Fixed attribute_annotate.py is not worked by KeyError: 'exceeded' #349

### DIFF
--- a/examples/nlp/data/steerlm/attribute_annotate.py
+++ b/examples/nlp/data/steerlm/attribute_annotate.py
@@ -71,7 +71,8 @@ def get_reward(
         reward_out = output_dict["rewards"].flatten().tolist()
 
         all_rewards.append(reward_out)
-        all_exceeded += output_dict["exceeded"].tolist()
+        if output_dict.get('exceeded', None) is not None:
+            all_exceeded += output_dict["exceeded"].tolist()
 
     return all_rewards, all_exceeded
 


### PR DESCRIPTION
# What does this PR do ?

Fixed attribute_annotate.py is not worked by KeyError: 'exceeded'. 
Behavior changes depending on whether or not "exceeded" exists.

# Changelog 
- Please update the [CHANGELOG.md](/CHANGELOG.md) under next version with high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? Make sure to also update the [NeMo Framework User Guide](https://docs.nvidia.com/nemo-framework/user-guide/latest/index.html) which contains the tutorials

# Checklist when contributing a new algorithm
- [ ] Does the trainer resume and restore model state all states?
- [ ] Does the trainer support all parallelism techniques(PP, TP, DP)?
- [ ] Does the trainer support `max_steps=-1` and `validation`?
- [ ] Does the trainer only call APIs defined in [alignable_interface.py](/nemo_aligner/models/alignable_interface.py)?
- [ ] Does the trainer have proper logging?

# Additional Information
* Related to #349
