### PR TITLE
fix: correct REINFORCE to resume training

### DIFF
--- a/nemo_aligner/utils/train_script_utils.py
+++ b/nemo_aligner/utils/train_script_utils.py
@@ -51,11 +51,13 @@ def retrieve_custom_trainer_state_dict(ptl_trainer):
         step = extract_value_from_ckpt(key="step", ckpt_path=trainer_restore_path)
         epoch = extract_value_from_ckpt(key="epoch", ckpt_path=trainer_restore_path)
         ppo_optimization_step = extract_value_from_ckpt(key="ppo_optimization_step", ckpt_path=trainer_restore_path)
+        reinforce_optimization_step = extract_value_from_ckpt(key="reinforce_optimization_step", ckpt_path=trainer_restore_path)
         trainer_state_dict = {
             "step": step,
             "consumed_samples": consumed_samples,
             "epoch": epoch,
             "ppo_optimization_step": ppo_optimization_step,
+            "reinforce_optimization_step": reinforce_optimization_step,
         }
 
     return trainer_state_dict

--- a/nemo_aligner/utils/train_script_utils.py
+++ b/nemo_aligner/utils/train_script_utils.py
@@ -50,6 +50,8 @@ def retrieve_custom_trainer_state_dict(ptl_trainer):
         consumed_samples = extract_value_from_ckpt(key="consumed_samples", ckpt_path=trainer_restore_path)
         step = extract_value_from_ckpt(key="step", ckpt_path=trainer_restore_path)
         epoch = extract_value_from_ckpt(key="epoch", ckpt_path=trainer_restore_path)
+
+        # TODO: unify alignment step key to avoid adding one for each algo
         ppo_optimization_step = extract_value_from_ckpt(key="ppo_optimization_step", ckpt_path=trainer_restore_path)
         reinforce_optimization_step = extract_value_from_ckpt(
             key="reinforce_optimization_step", ckpt_path=trainer_restore_path

--- a/nemo_aligner/utils/train_script_utils.py
+++ b/nemo_aligner/utils/train_script_utils.py
@@ -51,7 +51,9 @@ def retrieve_custom_trainer_state_dict(ptl_trainer):
         step = extract_value_from_ckpt(key="step", ckpt_path=trainer_restore_path)
         epoch = extract_value_from_ckpt(key="epoch", ckpt_path=trainer_restore_path)
         ppo_optimization_step = extract_value_from_ckpt(key="ppo_optimization_step", ckpt_path=trainer_restore_path)
-        reinforce_optimization_step = extract_value_from_ckpt(key="reinforce_optimization_step", ckpt_path=trainer_restore_path)
+        reinforce_optimization_step = extract_value_from_ckpt(
+            key="reinforce_optimization_step", ckpt_path=trainer_restore_path
+        )
         trainer_state_dict = {
             "step": step,
             "consumed_samples": consumed_samples,


### PR DESCRIPTION
# What does this PR do ?

Add reinforce optimization step to retrieve_custom_trainer_state_dict, which allows for training reinforce with multiple jobs.

# Changelog 
- Please update the [CHANGELOG.md](/CHANGELOG.md) under next version with high level changes in this PR.

# Usage
* You can potentially add a usage example below

# Before your PR is "Ready for review"
**Pre checks**:
- [ Y] Make sure you read and followed [Contributor guidelines](/CONTRIBUTING.md)
- [ N] Did you write any new necessary tests?
- [ N] Did you add or update any necessary documentation? Make sure to also update the [NeMo Framework User Guide](https://docs.nvidia.com/nemo-framework/user-guide/latest/index.html) which contains the tutorials

# Checklist when contributing a new algorithm
- [ ] Does the trainer resume and restore model state all states?
- [ ] Does the trainer support all parallelism techniques(PP, TP, DP)?
- [ ] Does the trainer support `max_steps=-1` and `validation`?
- [ ] Does the trainer only call APIs defined in [alignable_interface.py](/nemo_aligner/models/alignable_interface.py)?
- [ ] Does the trainer have proper logging?

# Additional Information
* Related to # (issue)
