### PR TITLE
fix: dev segment in version specifier joined properly

### DIFF
--- a/nemo_aligner/package_info.py
+++ b/nemo_aligner/package_info.py
@@ -29,7 +29,7 @@ if VERSION[3] != "":
     __version__ = __version__ + VERSION[3]
 
 if VERSION[4] != "":
-    __version__ = __version__ + "." + ".".join(VERSION[4])
+    __version__ = __version__ + "." + ".".join(VERSION[4:])
 
 __package_name__ = "nemo_aligner"
 __contact_names__ = "NVIDIA"


### PR DESCRIPTION
# What does this PR do ?

Instead of `0.6.0rc0.dev` we were creating this `0.6.0rc0.d.e.v.0`

# Changelog 
- Please update the [CHANGELOG.md](/CHANGELOG.md) under next version with high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? Make sure to also update the [NeMo Framework User Guide](https://docs.nvidia.com/nemo-framework/user-guide/latest/index.html) which contains the tutorials

# Checklist when contributing a new algorithm
- [ ] Does the trainer resume and restore model state all states?
- [ ] Does the trainer support all parallelism techniques(PP, TP, DP)?
- [ ] Does the trainer support `max_steps=-1` and `validation`?
- [ ] Does the trainer only call APIs defined in [alignable_interface.py](/nemo_aligner/models/alignable_interface.py)?
- [ ] Does the trainer have proper logging?

# Additional Information
* Related to # (issue)
