### PR TITLE
fix: Call trt_llm_exporter.build with vocab_size override for qwen support

### DIFF
--- a/nemo_aligner/utils/trt_llm.py
+++ b/nemo_aligner/utils/trt_llm.py
@@ -167,12 +167,13 @@ class GPTGenerateTRTLLM:
                 max_batch_size=self.generation_batch_size,
                 use_refit=True,
                 reshard_model=self.reshard_model,
+                vocab_size=model.module.vocab_size,
             )
             self._trtllm_model_compiled = True
             log_memory("After TRT-LLM engine build")
         else:
             log_memory("Before TRT-LLM engine refit")
-            self.trt_llm_exporter.refit(model, self.model_cfg)
+            self.trt_llm_exporter.refit(model, self.model_cfg, vocab_size=model.module.vocab_size)
             log_memory("After TRT-LLM engine refit")
 
     def _generate(self, inputs: tuple[torch.Tensor, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:

--- a/nemo_aligner/utils/trt_llm.py
+++ b/nemo_aligner/utils/trt_llm.py
@@ -167,7 +167,7 @@ class GPTGenerateTRTLLM:
                 max_batch_size=self.generation_batch_size,
                 use_refit=True,
                 reshard_model=self.reshard_model,
-                vocab_size=model.module.vocab_size,
+                vocab_size=self.model_cfg.get('override_vocab_size', None),
             )
             self._trtllm_model_compiled = True
             log_memory("After TRT-LLM engine build")

--- a/nemo_aligner/utils/trt_llm.py
+++ b/nemo_aligner/utils/trt_llm.py
@@ -173,7 +173,7 @@ class GPTGenerateTRTLLM:
             log_memory("After TRT-LLM engine build")
         else:
             log_memory("Before TRT-LLM engine refit")
-            self.trt_llm_exporter.refit(model, self.model_cfg, vocab_size=model.module.vocab_size)
+            self.trt_llm_exporter.refit(model, self.model_cfg)
             log_memory("After TRT-LLM engine refit")
 
     def _generate(self, inputs: tuple[torch.Tensor, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:

--- a/nemo_aligner/utils/trt_llm.py
+++ b/nemo_aligner/utils/trt_llm.py
@@ -167,7 +167,7 @@ class GPTGenerateTRTLLM:
                 max_batch_size=self.generation_batch_size,
                 use_refit=True,
                 reshard_model=self.reshard_model,
-                vocab_size=self.model_cfg.get('override_vocab_size', None),
+                vocab_size=self.model_cfg.get("override_vocab_size", None),
             )
             self._trtllm_model_compiled = True
             log_memory("After TRT-LLM engine build")


### PR DESCRIPTION
# What does this PR do ?

Dependent on this NeMo PR: https://github.com/NVIDIA/NeMo/pull/11982. Calls trt_llm_exporter.build with a vocab_size override of `model.module.vocab_size`, which is the padded vocab size. This is added for qwen support since qwen has an odd vocab size (151665) and otherwise cannot be used with tensor parallel.

# Changelog 
- Please update the [CHANGELOG.md](/CHANGELOG.md) under next version with high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? Make sure to also update the [NeMo Framework User Guide](https://docs.nvidia.com/nemo-framework/user-guide/latest/index.html) which contains the tutorials

# Checklist when contributing a new algorithm
- [ ] Does the trainer resume and restore model state all states?
- [ ] Does the trainer support all parallelism techniques(PP, TP, DP)?
- [ ] Does the trainer support `max_steps=-1` and `validation`?
- [ ] Does the trainer only call APIs defined in [alignable_interface.py](/nemo_aligner/models/alignable_interface.py)?
- [ ] Does the trainer have proper logging?

# Additional Information
* Related to # (issue)
