### PR TITLE
fix: remove spammy warning about the old dpo dataset format

### DIFF
--- a/nemo_aligner/data/nlp/datasets.py
+++ b/nemo_aligner/data/nlp/datasets.py
@@ -445,9 +445,6 @@ class DPOModelDataset(Dataset):
             prompt_fmtd = payload["prompt"]
             chosen_fmtd = payload["prompt"] + payload["chosen_response"]
             rejected_fmtd = payload["prompt"] + payload["rejected_response"]
-            logging.warning(
-                "Pre-formatting chat conversation as string with hardcoded chat tokens will be deprecated."
-            )  # (@adithyare) this will spam the console for now.
         else:
             prompt_fmtd = self.convert(payload["prompt"])  # (@adithyare) read var as "prompt formatted"
             chosen_fmtd = self.convert(payload["prompt"] + [payload["chosen_response"]])


### PR DESCRIPTION
# What does this PR do ?

Removes the warning log for the old dpo dataset format since it cluttered people's terminals and made it hard to watch their progress

![image](https://github.com/user-attachments/assets/097e85f7-dbc2-473b-b0d8-21d78f15b141)


# Changelog 
- Please update the [CHANGELOG.md](/CHANGELOG.md) under next version with high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? Make sure to also update the [NeMo Framework User Guide](https://docs.nvidia.com/nemo-framework/user-guide/latest/index.html) which contains the tutorials

# Checklist when contributing a new algorithm
- [ ] Does the trainer resume and restore model state all states?
- [ ] Does the trainer support all parallelism techniques(PP, TP, DP)?
- [ ] Does the trainer support `max_steps=-1` and `validation`?
- [ ] Does the trainer only call APIs defined in [alignable_interface.py](/nemo_aligner/models/alignable_interface.py)?
- [ ] Does the trainer have proper logging?

# Additional Information
* Related to # (issue)
