### PR TITLE
feat: enable reward model training with multiple validation datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,12 +38,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
     ```
 - Add code and instructions for replicating Reward Modeling training in HelpSteer2 and HelpSteer2-Preference
 - Implement REINFORCE algorithm.
+- Add support for multiple validation sets when training a Reward Model.
 
 ### Breaking Changes
 - Upgrade TRTLLM dependency from v0.10.0 to v0.12.0 and migrate from `GPTSession` cpp runtime to `ModelRunner` python runtime. Please use the latest Dockerfile.
 - Using latest TransformerEngine versions may require `++model.dist_ckpt_load_strictness=log_all` when loading from a older pre-existing checkpoint to not error out.
 - NeMo-Aligner now requires Megatron-LM==0.9.0 for the APIs to calculate the microbatch sizes (API introduced `megatron.core.num_microbatches_calculator.reconfigure_num_microbatch_calculator`).
 - NeMo-Aligner now requires a version of NeMo with this change to how the MoE spec is handled: https://github.com/NVIDIA/NeMo/pull/9035 .
+- Validation metrics of the SupervisedTrainer (used by SFT and Reward Model) are now logged in Weights&Biases as <validation_key>/<metric_name> instead of val/<metric_name>.
 
 ### Bug Fixes
 - It is now required, for stability, to add `export NCCL_ALGO=...` to scripts launching PPO training loop. Please see the [RLHF docs](./docs/user-guide/rlhf.rst) for information.

--- a/examples/nlp/gpt/conf/training_rm.yaml
+++ b/examples/nlp/gpt/conf/training_rm.yaml
@@ -113,7 +113,8 @@ model:
     reset_attention_mask: False # Reset attention mask after end-of-document token
     eod_mask_loss: False # Mask loss for the end of document tokens
     index_mapping_dir: null # path to save index mapping .npy files, by default will save in the same location as data_prefix
-    data_prefix: null
+    data_prefix: null # For multiple validation sets, use a dictionary that includes one key named `validation`
+    # (main validation set) and extra keys of the form `validation*` (secondary validation sets).
 
   precision: ${trainer.precision}
 

--- a/examples/nlp/gpt/conf/training_rm.yaml
+++ b/examples/nlp/gpt/conf/training_rm.yaml
@@ -113,8 +113,11 @@ model:
     reset_attention_mask: False # Reset attention mask after end-of-document token
     eod_mask_loss: False # Mask loss for the end of document tokens
     index_mapping_dir: null # path to save index mapping .npy files, by default will save in the same location as data_prefix
-    data_prefix: null # For multiple validation sets, use a dictionary that includes one key named `validation`
-    # (main validation set) and extra keys of the form `validation*` (secondary validation sets).
+
+    # For multiple validation sets, use a dictionary that includes one key named `validation` (main
+    # validation set) and extra keys of the form `validation*` (secondary validation sets), for instance:
+    # model.data.data_prefix="{train:[train.jsonl],validation:[valid.jsonl],validation_set2:[valid2.jsonl],test:[test.jsonl]}"
+    data_prefix: null
 
   precision: ${trainer.precision}
 

--- a/examples/nlp/gpt/train_reward_model.py
+++ b/examples/nlp/gpt/train_reward_model.py
@@ -24,6 +24,7 @@ from nemo_aligner.data.nlp.builders import (
     build_train_valid_test_regression_rm_datasets,
     build_train_valid_test_rm_datasets,
 )
+from nemo_aligner.data.nlp.datasets import RewardModelDataset
 from nemo_aligner.models.nlp.gpt.reward_model_classes import REWARD_MODEL_CLASS_DICT, RewardModelType
 from nemo_aligner.utils.distributed import Timer
 from nemo_aligner.utils.train_script_utils import (
@@ -36,7 +37,6 @@ from nemo_aligner.utils.train_script_utils import (
     retrieve_custom_trainer_state_dict,
 )
 from nemo_aligner.utils.utils import load_and_override_model_config, load_from_nemo
-from nemo_aligner.data.nlp.datasets import RewardModelDataset
 
 """Script to start Reward Model training"""
 

--- a/nemo_aligner/algorithms/supervised.py
+++ b/nemo_aligner/algorithms/supervised.py
@@ -73,7 +73,8 @@ class SupervisedTrainer:
             self.train_dataloader.batch_sampler, self.cfg.get("limit_train_batches", 1.0)
         )
         self.dict_limit_val_batches = {
-            key: compute_limit_batches(len(val_dataloader), self.cfg.limit_val_batches) for key, val_dataloader in self.val_dataloaders.items()
+            key: compute_limit_batches(len(val_dataloader), self.cfg.limit_val_batches)
+            for key, val_dataloader in self.val_dataloaders.items()
         }
         self.val_check_interval = (
             int(self.cfg.val_check_interval * self.num_steps_per_epoch)

--- a/nemo_aligner/data/nlp/builders.py
+++ b/nemo_aligner/data/nlp/builders.py
@@ -199,7 +199,9 @@ def build_train_valid_test_datasets(
 
         for key in data_prefix.keys():
             if key not in ["train", "test"] and key.startswith("validation") is False:
-                raise NotImplementedError(f"Unsupported key '{key}' found in data_prefix. Supported keys are: 'train', 'validation*', and 'test'.")
+                raise NotImplementedError(
+                    f"Unsupported key '{key}' found in data_prefix. Supported keys are: 'train', 'validation*', and 'test'."
+                )
 
         train_ds = build_dataset_generic(
             cls=cls,

--- a/nemo_aligner/data/nlp/builders.py
+++ b/nemo_aligner/data/nlp/builders.py
@@ -198,7 +198,7 @@ def build_train_valid_test_datasets(
             test_n_chunks = n_chunks
 
         for key in data_prefix.keys():
-            if key not in ["train", "test"] and key.startswith("validation") is False:
+            if key not in ["train", "test"] and not key.startswith("validation"):
                 raise NotImplementedError(
                     f"Unsupported key '{key}' found in data_prefix. Supported keys are: 'train', 'validation*', and 'test'."
                 )
@@ -217,37 +217,26 @@ def build_train_valid_test_datasets(
             n_examples_per_chunk=train_examples_per_chunk,
         )
         validation_keys = [key for key in data_prefix if key.startswith("validation")]
-        if len(validation_keys) <= 1:
-            validation_ds = build_dataset_generic(
+        validation_ds = {
+            key: build_dataset_generic(
                 cls=cls,
                 cfg=cfg,
-                data_prefix=data_prefix["validation"],
+                data_prefix=data_prefix[key],
                 data_impl=data_impl,
                 num_samples=int(train_valid_test_num_samples[1]),
                 seq_length=seq_length,
                 seed=seed,
                 tokenizer=tokenizer,
-                name="validation",
+                name=key,
                 n_chunks=validation_n_chunks,
                 n_examples_per_chunk=validation_examples_per_chunk,
             )
-        else:
-            validation_ds = {
-                key: build_dataset_generic(
-                    cls=cls,
-                    cfg=cfg,
-                    data_prefix=data_prefix[key],
-                    data_impl=data_impl,
-                    num_samples=int(train_valid_test_num_samples[1]),
-                    seq_length=seq_length,
-                    seed=seed,
-                    tokenizer=tokenizer,
-                    name=key,
-                    n_chunks=validation_n_chunks,
-                    n_examples_per_chunk=validation_examples_per_chunk,
-                )
-                for key in validation_keys
-            }
+            for key in validation_keys
+        }
+        if len(validation_ds) <= 1:
+            assert len(validation_ds) == 1, "No validation key found in data_prefix"
+            validation_ds = next(iter(validation_ds.values()))  # Use validation dataset directly instead of a dict
+
         test_ds = build_dataset_generic(
             cls=cls,
             cfg=cfg,

--- a/nemo_aligner/data/nlp/builders.py
+++ b/nemo_aligner/data/nlp/builders.py
@@ -197,6 +197,10 @@ def build_train_valid_test_datasets(
             validation_n_chunks = n_chunks
             test_n_chunks = n_chunks
 
+        for key in data_prefix.keys():
+            if key not in ["train", "test"] and key.startswith("validation") is False:
+                raise NotImplementedError(f"Unsupported key '{key}' found in data_prefix. Supported keys are: 'train', 'validation*', and 'test'.")
+
         train_ds = build_dataset_generic(
             cls=cls,
             cfg=cfg,
@@ -210,19 +214,38 @@ def build_train_valid_test_datasets(
             n_chunks=train_n_chunks,
             n_examples_per_chunk=train_examples_per_chunk,
         )
-        validation_ds = build_dataset_generic(
-            cls=cls,
-            cfg=cfg,
-            data_prefix=data_prefix["validation"],
-            data_impl=data_impl,
-            num_samples=int(train_valid_test_num_samples[1]),
-            seq_length=seq_length,
-            seed=seed,
-            tokenizer=tokenizer,
-            name="validation",
-            n_chunks=validation_n_chunks,
-            n_examples_per_chunk=validation_examples_per_chunk,
-        )
+        validation_keys = [key for key in data_prefix if key.startswith("validation")]
+        if len(validation_keys) <= 1:
+            validation_ds = build_dataset_generic(
+                cls=cls,
+                cfg=cfg,
+                data_prefix=data_prefix["validation"],
+                data_impl=data_impl,
+                num_samples=int(train_valid_test_num_samples[1]),
+                seq_length=seq_length,
+                seed=seed,
+                tokenizer=tokenizer,
+                name="validation",
+                n_chunks=validation_n_chunks,
+                n_examples_per_chunk=validation_examples_per_chunk,
+            )
+        else:
+            validation_ds = {
+                key: build_dataset_generic(
+                    cls=cls,
+                    cfg=cfg,
+                    data_prefix=data_prefix[key],
+                    data_impl=data_impl,
+                    num_samples=int(train_valid_test_num_samples[1]),
+                    seq_length=seq_length,
+                    seed=seed,
+                    tokenizer=tokenizer,
+                    name=key,
+                    n_chunks=validation_n_chunks,
+                    n_examples_per_chunk=validation_examples_per_chunk,
+                )
+                for key in validation_keys
+            }
         test_ds = build_dataset_generic(
             cls=cls,
             cfg=cfg,


### PR DESCRIPTION
# What does this PR do ?

This PR enables reward model training with multiple validation datasets.

# Usage

In addition to a main validation dataset, you can optionally specify additional validation datasets in data_prefix. The additional keys should start with "validation". Metrics are computed for each validation dataset and logged in separate wandb tabs.

Before:
```python
python ${NEMO_ALIGNER_PATH}/examples/nlp/gpt/train_reward_model.py \
    ...
    ++model.data.data_prefix="{train:[${TRAIN_DATA}],validation:[${VAL_DATA}],test:[${TEST_DATA}]}" \
    ...
```

After:
```python
python ${NEMO_ALIGNER_PATH}/examples/nlp/gpt/train_reward_model.py \
    ...
    ++model.data.data_prefix="{train:[${TRAIN_DATA}],validation:[${VAL_DATA}],validation_other:[${VAL_OTHER_DATA}],test:[${TEST_DATA}]}" \
    ...
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? Make sure to also update the [NeMo Framework User Guide](https://docs.nvidia.com/nemo-framework/user-guide/latest/index.html) which contains the tutorials

# Checklist when contributing a new algorithm
- [x] Does the trainer resume and restore model state all states?
- [x] Does the trainer support all parallelism techniques(PP, TP, DP)?
- [x] Does the trainer support `max_steps=-1` and `validation`?
- [x] Does the trainer only call APIs defined in [alignable_interface.py](/nemo_aligner/models/alignable_interface.py)?
- [x] Does the trainer have proper logging?

# Additional Information
* Related to # (issue)
